### PR TITLE
Issue #10: Add downstream auth modes for LiteLLM E2E

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,17 @@ DEFAULT_BACKEND_TARGET=http://localhost:4000/v1
 
 # LiteLLM/OpenAI-compatible downstream (when set, Mux forwards requests here)
 DOWNSTREAM_BASE_URL=http://localhost:4000/v1
-# Optional if your LiteLLM endpoint is unsecured locally
+# Optional key used for downstream auth, based on DOWNSTREAM_AUTH_MODE
 DOWNSTREAM_API_KEY=
+# How Mux authenticates to downstream: bearer | x-api-key | passthrough | none
+# - bearer: sends Authorization: Bearer <DOWNSTREAM_API_KEY>
+# - x-api-key: sends x-api-key: <DOWNSTREAM_API_KEY>
+# - passthrough: forwards inbound Authorization header from client request
+# - none: sends no auth header
+DOWNSTREAM_AUTH_MODE=bearer
+# Optional JSON map of additional static headers sent to downstream
+# Example: {"anthropic-version":"2023-06-01"}
+DOWNSTREAM_EXTRA_HEADERS={}
 # Request timeout for downstream call (milliseconds)
 DOWNSTREAM_TIMEOUT_MS=30000
 # If true and DOWNSTREAM_BASE_URL is empty, Mux returns the local mock response.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ litellm --host 0.0.0.0 --port 4000
 
 ```bash
 DOWNSTREAM_BASE_URL=http://localhost:4000/v1
-DOWNSTREAM_API_KEY= # optional
+DOWNSTREAM_API_KEY= # optional, based on auth mode
+DOWNSTREAM_AUTH_MODE=bearer
+DOWNSTREAM_EXTRA_HEADERS={}
 DOWNSTREAM_TIMEOUT_MS=30000
 DOWNSTREAM_MOCK_FALLBACK=false
 ```
@@ -144,6 +146,12 @@ curl -s http://localhost:8787/v1/chat/completions \
 - Else, `gpt-4o` is downgraded to `gpt-4o-mini` for simple prompts.
 - If prompt appears complex (basic keyword heuristic), model is kept.
 - If `DOWNSTREAM_BASE_URL` is set, Mux forwards to `${DOWNSTREAM_BASE_URL}/chat/completions` with the resolved model.
+- Downstream auth is configurable via `DOWNSTREAM_AUTH_MODE`:
+  - `bearer` (default): `Authorization: Bearer ${DOWNSTREAM_API_KEY}`
+  - `x-api-key`: `x-api-key: ${DOWNSTREAM_API_KEY}`
+  - `passthrough`: forwards inbound `Authorization` header as-is
+  - `none`: no auth header
+- Optional static headers can be added with `DOWNSTREAM_EXTRA_HEADERS` (JSON map).
 - If `DOWNSTREAM_BASE_URL` is not set:
   - and `DOWNSTREAM_MOCK_FALLBACK=true`, Mux returns an explicit local mock response (safe dev path)
   - and `DOWNSTREAM_MOCK_FALLBACK=false`, Mux returns `503 service_unavailable`
@@ -156,7 +164,9 @@ curl -s http://localhost:8787/v1/chat/completions \
 - `DEFAULT_PROVIDER` (metadata for logs)
 - `DEFAULT_BACKEND_TARGET` (metadata for logs)
 - `DOWNSTREAM_BASE_URL` (e.g. `http://localhost:4000/v1`)
-- `DOWNSTREAM_API_KEY` (optional bearer token)
+- `DOWNSTREAM_API_KEY` (optional key/token for downstream auth)
+- `DOWNSTREAM_AUTH_MODE` (`bearer` default, `x-api-key`, `passthrough`, `none`)
+- `DOWNSTREAM_EXTRA_HEADERS` (JSON map, optional extra headers)
 - `DOWNSTREAM_TIMEOUT_MS` (default `30000`)
 - `DOWNSTREAM_MOCK_FALLBACK` (default true outside production)
 

--- a/docs/issue-10-downstream-e2e.md
+++ b/docs/issue-10-downstream-e2e.md
@@ -1,0 +1,58 @@
+# Issue #10 — Downstream E2E plan (Mux -> LiteLLM -> real provider)
+
+## Recommended first path (most reliable)
+
+Use **Mux -> LiteLLM with API-key auth** first, not OAuth:
+
+1. Run LiteLLM as OpenAI-compatible proxy (`/v1/chat/completions`)
+2. Configure LiteLLM with real provider keys (OpenAI and/or Anthropic)
+3. Give Mux a LiteLLM-facing key (`DOWNSTREAM_API_KEY`) and use `DOWNSTREAM_AUTH_MODE=bearer`
+4. Validate Mux request succeeds with `DOWNSTREAM_MOCK_FALLBACK=false`
+
+Why first:
+- smallest moving parts
+- aligns with Mux default OpenAI-compatible contract
+- avoids current OAuth edge-case risk, especially Anthropic passthrough
+
+## Auth mode support in Mux
+
+Mux now supports these downstream auth modes:
+
+- `bearer` (default): `Authorization: Bearer <DOWNSTREAM_API_KEY>`
+- `x-api-key`: `x-api-key: <DOWNSTREAM_API_KEY>`
+- `passthrough`: forwards inbound `Authorization` header
+- `none`: sends no auth header
+
+Also supports `DOWNSTREAM_EXTRA_HEADERS` for provider/proxy-specific headers.
+
+## LiteLLM auth maturity snapshot
+
+Based on docs + open issues:
+
+- **OpenAI API key auth:** mature, recommended now
+- **Anthropic API key auth:** mature, recommended now
+- **OpenAI OAuth / custom OpenAI-compatible OAuth:** possible, but more config + less battle-tested than API key for this setup
+- **Anthropic OAuth passthrough:** not reliable enough to be first path (known header-handling issues have existed)
+
+## Practical execution order
+
+1. **Land Mux auth-mode flexibility** (this PR)
+2. Stand up/test LiteLLM with API-key based provider config
+3. Validate E2E via curl against Mux (mock fallback disabled)
+4. Only after stable E2E, evaluate optional OAuth track in a separate issue/PR
+
+## Example env for initial E2E
+
+```bash
+DOWNSTREAM_BASE_URL=http://<litellm-host>:4000/v1
+DOWNSTREAM_API_KEY=<litellm-virtual-or-proxy-key>
+DOWNSTREAM_AUTH_MODE=bearer
+DOWNSTREAM_EXTRA_HEADERS={}
+DOWNSTREAM_MOCK_FALLBACK=false
+```
+
+If downstream expects `x-api-key` instead:
+
+```bash
+DOWNSTREAM_AUTH_MODE=x-api-key
+```

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import {
   callDownstream,
   DownstreamNotConfiguredError,
   DownstreamRequestError,
+  type DownstreamRequestContext,
 } from "./downstream.js";
 import { resolveRoute } from "./policy.js";
 import type { ChatCompletionsRequest } from "./types.js";
@@ -48,7 +49,11 @@ export const createApp = () => {
     });
 
     try {
-      const downstream = await callDownstream(body, route);
+      const downstreamContext: DownstreamRequestContext = {
+        incomingAuthorizationHeader: req.header("authorization") ?? undefined,
+      };
+
+      const downstream = await callDownstream(body, route, downstreamContext);
       return res.status(200).json(downstream);
     } catch (error) {
       if (error instanceof DownstreamNotConfiguredError) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,21 +3,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const parseModelMap = (input: string | undefined): Record<string, string> => {
-  if (!input) return {};
-
-  try {
-    const parsed = JSON.parse(input);
-    if (parsed && typeof parsed === "object") {
-      const entries = Object.entries(parsed).filter(
-        ([k, v]) => typeof k === "string" && typeof v === "string",
-      ) as Array<[string, string]>;
-      return Object.fromEntries(entries);
-    }
-  } catch {
-    // ignore invalid map and fall back to empty map
-  }
-
-  return {};
+  return parseJsonMap(input);
 };
 
 const parseBoolean = (input: string | undefined, defaultValue: boolean): boolean => {
@@ -39,6 +25,35 @@ const normalizeBaseUrl = (input: string | undefined): string | null => {
   return input.replace(/\/+$/, "");
 };
 
+type DownstreamAuthMode = "none" | "bearer" | "x-api-key" | "passthrough";
+
+const parseDownstreamAuthMode = (input: string | undefined): DownstreamAuthMode => {
+  const normalized = input?.trim().toLowerCase();
+
+  if (normalized === "none") return "none";
+  if (normalized === "x-api-key") return "x-api-key";
+  if (normalized === "passthrough") return "passthrough";
+  return "bearer";
+};
+
+const parseJsonMap = (input: string | undefined): Record<string, string> => {
+  if (!input) return {};
+
+  try {
+    const parsed = JSON.parse(input);
+    if (parsed && typeof parsed === "object") {
+      const entries = Object.entries(parsed).filter(
+        ([k, v]) => typeof k === "string" && typeof v === "string",
+      ) as Array<[string, string]>;
+      return Object.fromEntries(entries);
+    }
+  } catch {
+    // ignore invalid map and fall back to empty map
+  }
+
+  return {};
+};
+
 export const config = {
   port: Number(process.env.PORT ?? 8787),
   nodeEnv: process.env.NODE_ENV ?? "development",
@@ -48,7 +63,9 @@ export const config = {
   modelMap: parseModelMap(process.env.MODEL_MAP),
   downstreamBaseUrl: normalizeBaseUrl(process.env.DOWNSTREAM_BASE_URL),
   downstreamApiKey: process.env.DOWNSTREAM_API_KEY,
+  downstreamAuthMode: parseDownstreamAuthMode(process.env.DOWNSTREAM_AUTH_MODE),
   downstreamTimeoutMs: parseNumber(process.env.DOWNSTREAM_TIMEOUT_MS, 30_000),
+  downstreamExtraHeaders: parseJsonMap(process.env.DOWNSTREAM_EXTRA_HEADERS),
   downstreamMockFallbackEnabled: parseBoolean(
     process.env.DOWNSTREAM_MOCK_FALLBACK,
     process.env.NODE_ENV !== "production",

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -84,19 +84,48 @@ const parseJsonSafely = async (response: Response): Promise<unknown> => {
   }
 };
 
+export type DownstreamRequestContext = {
+  incomingAuthorizationHeader?: string;
+};
+
+const resolveAuthHeader = (context?: DownstreamRequestContext): string | null => {
+  if (config.downstreamAuthMode === "none") return null;
+
+  if (config.downstreamAuthMode === "passthrough") {
+    const value = context?.incomingAuthorizationHeader?.trim();
+    return value ? value : null;
+  }
+
+  const token = config.downstreamApiKey?.trim();
+  if (!token) return null;
+
+  if (config.downstreamAuthMode === "x-api-key") {
+    return token;
+  }
+
+  return `Bearer ${token}`;
+};
+
 const callLiteLLM = async (
   req: ChatCompletionsRequest,
   route: RouteDecision,
+  context?: DownstreamRequestContext,
 ): Promise<DownstreamResponse> => {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), config.downstreamTimeoutMs);
 
   const headers: Record<string, string> = {
     "content-type": "application/json",
+    ...config.downstreamExtraHeaders,
   };
 
-  if (config.downstreamApiKey) {
-    headers.authorization = `Bearer ${config.downstreamApiKey}`;
+  const authHeader = resolveAuthHeader(context);
+  if (authHeader) {
+    if (config.downstreamAuthMode === "x-api-key") {
+      headers["x-api-key"] = authHeader;
+    } else {
+      headers.authorization = authHeader;
+    }
   }
 
   const payload = {
@@ -125,6 +154,7 @@ const callLiteLLM = async (
 export const callDownstream = async (
   req: ChatCompletionsRequest,
   route: RouteDecision,
+  context?: DownstreamRequestContext,
 ): Promise<DownstreamResponse> => {
   if (!config.downstreamBaseUrl) {
     if (config.downstreamMockFallbackEnabled) {
@@ -136,5 +166,5 @@ export const callDownstream = async (
     );
   }
 
-  return callLiteLLM(req, route);
+  return callLiteLLM(req, route, context);
 };

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -25,9 +25,13 @@ describe("callDownstream", () => {
   it("calls LiteLLM-compatible endpoint when configured", async () => {
     const previousBaseUrl = config.downstreamBaseUrl;
     const previousApiKey = config.downstreamApiKey;
+    const previousAuthMode = config.downstreamAuthMode;
+    const previousExtraHeaders = config.downstreamExtraHeaders;
 
     config.downstreamBaseUrl = "http://127.0.0.1:4000/v1";
     config.downstreamApiKey = "test-key";
+    config.downstreamAuthMode = "bearer";
+    config.downstreamExtraHeaders = { "x-mux-test": "1" };
 
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
@@ -55,14 +59,94 @@ describe("callDownstream", () => {
 
     const requestInit = fetchSpy.mock.calls[0]?.[1] as RequestInit;
     expect(requestInit.method).toBe("POST");
-    expect((requestInit.headers as Record<string, string>).authorization).toBe(
-      "Bearer test-key",
-    );
+    const headers = requestInit.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer test-key");
+    expect(headers["x-mux-test"]).toBe("1");
 
     expect(response.model).toBe("gpt-4o-mini");
 
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamApiKey = previousApiKey;
+    config.downstreamAuthMode = previousAuthMode;
+    config.downstreamExtraHeaders = previousExtraHeaders;
+  });
+
+  it("supports x-api-key auth mode for downstream", async () => {
+    const previousBaseUrl = config.downstreamBaseUrl;
+    const previousApiKey = config.downstreamApiKey;
+    const previousAuthMode = config.downstreamAuthMode;
+
+    config.downstreamBaseUrl = "http://127.0.0.1:4000/v1";
+    config.downstreamApiKey = "abc123";
+    config.downstreamAuthMode = "x-api-key";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-1",
+          object: "chat.completion",
+          created: 123,
+          model: "gpt-4o-mini",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "hello" },
+              finish_reason: "stop",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await callDownstream(requestPayload, route);
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const headers = requestInit.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("abc123");
+    expect(headers.authorization).toBeUndefined();
+
+    config.downstreamBaseUrl = previousBaseUrl;
+    config.downstreamApiKey = previousApiKey;
+    config.downstreamAuthMode = previousAuthMode;
+  });
+
+  it("supports passthrough auth mode", async () => {
+    const previousBaseUrl = config.downstreamBaseUrl;
+    const previousAuthMode = config.downstreamAuthMode;
+
+    config.downstreamBaseUrl = "http://127.0.0.1:4000/v1";
+    config.downstreamAuthMode = "passthrough";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-1",
+          object: "chat.completion",
+          created: 123,
+          model: "gpt-4o-mini",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "hello" },
+              finish_reason: "stop",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await callDownstream(requestPayload, route, {
+      incomingAuthorizationHeader: "Bearer passthrough-token",
+    });
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const headers = requestInit.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer passthrough-token");
+
+    config.downstreamBaseUrl = previousBaseUrl;
+    config.downstreamAuthMode = previousAuthMode;
   });
 
   it("throws when not configured and fallback disabled", async () => {


### PR DESCRIPTION
## Summary
- add configurable downstream auth mode for forwarding from Mux to LiteLLM/OpenAI-compatible backends
- support `bearer` (default), `x-api-key`, `passthrough`, and `none`
- add `DOWNSTREAM_EXTRA_HEADERS` for provider/proxy-specific static headers
- document recommended issue #10 execution path (Mux -> LiteLLM -> real provider API key first)
- add tests for bearer/x-api-key/passthrough behavior

## Why
Issue #10 is blocked on downstream auth contract ambiguity. Mux previously always sent `Authorization: Bearer $DOWNSTREAM_API_KEY`, which is too rigid for different downstreams.

This keeps Max untouched and makes Mux flexible enough to prove real downstream E2E first.

## Validation
- `npm test` (11 tests passed)

## Follow-up (post-merge)
1. point Mux at the intended LiteLLM proxy
2. set `DOWNSTREAM_MOCK_FALLBACK=false`
3. use API-key mode first (`bearer` or `x-api-key` depending on downstream)
4. verify end-to-end request with real provider response

Refs #10