### PR TITLE
feat: add optional Anthropic Node SDK adapter mode for OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,12 @@ MODEL_MAP={"gpt-4o":"gpt-4o-mini"}
 DEFAULT_PROVIDER=openai-compatible
 DEFAULT_BACKEND_TARGET=http://localhost:4000/v1
 
-# LiteLLM/OpenAI-compatible downstream (when set, Mux forwards requests here)
+# Downstream mode
+# - openai-compatible: forwards to DOWNSTREAM_BASE_URL/chat/completions (default)
+# - anthropic-sdk: calls Anthropic via official Node SDK (required for OAuth token path)
+DOWNSTREAM_MODE=openai-compatible
+
+# OpenAI-compatible downstream (used when DOWNSTREAM_MODE=openai-compatible)
 DOWNSTREAM_BASE_URL=http://localhost:4000/v1
 # Optional key used for downstream auth, based on DOWNSTREAM_AUTH_MODE
 DOWNSTREAM_API_KEY=
@@ -28,3 +33,12 @@ DOWNSTREAM_TIMEOUT_MS=30000
 # If true and DOWNSTREAM_BASE_URL is empty, Mux returns the local mock response.
 # Defaults to true outside production, false in production.
 DOWNSTREAM_MOCK_FALLBACK=true
+
+# Anthropic SDK adapter (used when DOWNSTREAM_MODE=anthropic-sdk)
+# OAuth path (preferred for Max-style account tokens):
+ANTHROPIC_OAUTH_TOKEN=
+# API key fallback (optional):
+ANTHROPIC_API_KEY=
+# Optional; if empty uses Anthropic default API endpoint.
+# For AgentWeave proxy: http://192.168.1.70:30400
+ANTHROPIC_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ litellm --host 0.0.0.0 --port 4000
 2. In `.env`, point Mux to LiteLLM:
 
 ```bash
+DOWNSTREAM_MODE=openai-compatible
 DOWNSTREAM_BASE_URL=http://localhost:4000/v1
 DOWNSTREAM_API_KEY= # optional, based on auth mode
 DOWNSTREAM_AUTH_MODE=bearer
@@ -121,6 +122,23 @@ DOWNSTREAM_MOCK_FALLBACK=false
 ```
 
 3. Start Mux (`npm run dev`) and send OpenAI-compatible requests to Mux.
+
+### Run with Anthropic OAuth via Node SDK (Option 2)
+
+This path is for Anthropic OAuth tokens (`sk-ant-oat01-*`) where raw HTTP/curl-style calls are not reliable.
+Mux uses the official `@anthropic-ai/sdk` directly.
+
+```bash
+DOWNSTREAM_MODE=anthropic-sdk
+ANTHROPIC_OAUTH_TOKEN=sk-ant-oat01-...
+ANTHROPIC_BASE_URL=http://192.168.1.70:30400
+DOWNSTREAM_TIMEOUT_MS=30000
+```
+
+Notes:
+- Keep sending OpenAI-compatible requests to Mux (`/v1/chat/completions`); Mux translates to Anthropic Messages API internally.
+- `ANTHROPIC_API_KEY` can be used instead of `ANTHROPIC_OAUTH_TOKEN` for non-OAuth setups.
+- In `anthropic-sdk` mode, LiteLLM/OpenAI downstream auth settings are ignored.
 
 ### Test
 
@@ -145,16 +163,21 @@ curl -s http://localhost:8787/v1/chat/completions \
 - If `MODEL_MAP` includes the requested model, that mapping wins.
 - Else, `gpt-4o` is downgraded to `gpt-4o-mini` for simple prompts.
 - If prompt appears complex (basic keyword heuristic), model is kept.
-- If `DOWNSTREAM_BASE_URL` is set, Mux forwards to `${DOWNSTREAM_BASE_URL}/chat/completions` with the resolved model.
-- Downstream auth is configurable via `DOWNSTREAM_AUTH_MODE`:
-  - `bearer` (default): `Authorization: Bearer ${DOWNSTREAM_API_KEY}`
-  - `x-api-key`: `x-api-key: ${DOWNSTREAM_API_KEY}`
-  - `passthrough`: forwards inbound `Authorization` header as-is
-  - `none`: no auth header
-- Optional static headers can be added with `DOWNSTREAM_EXTRA_HEADERS` (JSON map).
-- If `DOWNSTREAM_BASE_URL` is not set:
-  - and `DOWNSTREAM_MOCK_FALLBACK=true`, Mux returns an explicit local mock response (safe dev path)
-  - and `DOWNSTREAM_MOCK_FALLBACK=false`, Mux returns `503 service_unavailable`
+- `DOWNSTREAM_MODE=openai-compatible` (default):
+  - If `DOWNSTREAM_BASE_URL` is set, Mux forwards to `${DOWNSTREAM_BASE_URL}/chat/completions` with the resolved model.
+  - Downstream auth is configurable via `DOWNSTREAM_AUTH_MODE`:
+    - `bearer` (default): `Authorization: Bearer ${DOWNSTREAM_API_KEY}`
+    - `x-api-key`: `x-api-key: ${DOWNSTREAM_API_KEY}`
+    - `passthrough`: forwards inbound `Authorization` header as-is
+    - `none`: no auth header
+  - Optional static headers can be added with `DOWNSTREAM_EXTRA_HEADERS` (JSON map).
+  - If `DOWNSTREAM_BASE_URL` is not set:
+    - and `DOWNSTREAM_MOCK_FALLBACK=true`, Mux returns an explicit local mock response (safe dev path)
+    - and `DOWNSTREAM_MOCK_FALLBACK=false`, Mux returns `503 service_unavailable`
+- `DOWNSTREAM_MODE=anthropic-sdk`:
+  - Mux calls Anthropic via Node SDK (`@anthropic-ai/sdk`) using `ANTHROPIC_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`).
+  - Optional `ANTHROPIC_BASE_URL` supports proxy endpoints like `http://192.168.1.70:30400`.
+  - Current limitations: no streaming support yet and chat role mapping is text-only (system/user/assistant; `tool` is flattened to text).
 
 ### Environment variables
 
@@ -163,12 +186,16 @@ curl -s http://localhost:8787/v1/chat/completions \
 - `MODEL_MAP` (JSON map for explicit model overrides)
 - `DEFAULT_PROVIDER` (metadata for logs)
 - `DEFAULT_BACKEND_TARGET` (metadata for logs)
-- `DOWNSTREAM_BASE_URL` (e.g. `http://localhost:4000/v1`)
-- `DOWNSTREAM_API_KEY` (optional key/token for downstream auth)
+- `DOWNSTREAM_MODE` (`openai-compatible` default, `anthropic-sdk`)
+- `DOWNSTREAM_BASE_URL` (e.g. `http://localhost:4000/v1`, openai-compatible mode)
+- `DOWNSTREAM_API_KEY` (optional key/token for openai-compatible mode)
 - `DOWNSTREAM_AUTH_MODE` (`bearer` default, `x-api-key`, `passthrough`, `none`)
 - `DOWNSTREAM_EXTRA_HEADERS` (JSON map, optional extra headers)
 - `DOWNSTREAM_TIMEOUT_MS` (default `30000`)
-- `DOWNSTREAM_MOCK_FALLBACK` (default true outside production)
+- `DOWNSTREAM_MOCK_FALLBACK` (default true outside production, openai-compatible mode)
+- `ANTHROPIC_OAUTH_TOKEN` (preferred in anthropic-sdk mode)
+- `ANTHROPIC_API_KEY` (optional fallback in anthropic-sdk mode)
+- `ANTHROPIC_BASE_URL` (optional override/proxy URL in anthropic-sdk mode)
 
 ### Structured logging fields
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mux",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.54.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "pino": "^9.3.2"
@@ -20,6 +21,15 @@
         "tsx": "^4.19.1",
         "typescript": "^5.6.2",
         "vitest": "^2.1.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.54.0.tgz",
+      "integrity": "sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.54.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "pino": "^9.3.2"

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,6 +46,7 @@ export const createApp = () => {
       routeReason: route.routeReason,
       provider: route.provider,
       backendTarget: route.backendTarget,
+      downstreamMode: config.downstreamMode,
     });
 
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ const normalizeBaseUrl = (input: string | undefined): string | null => {
 };
 
 type DownstreamAuthMode = "none" | "bearer" | "x-api-key" | "passthrough";
+type DownstreamMode = "openai-compatible" | "anthropic-sdk";
 
 const parseDownstreamAuthMode = (input: string | undefined): DownstreamAuthMode => {
   const normalized = input?.trim().toLowerCase();
@@ -34,6 +35,12 @@ const parseDownstreamAuthMode = (input: string | undefined): DownstreamAuthMode 
   if (normalized === "x-api-key") return "x-api-key";
   if (normalized === "passthrough") return "passthrough";
   return "bearer";
+};
+
+const parseDownstreamMode = (input: string | undefined): DownstreamMode => {
+  const normalized = input?.trim().toLowerCase();
+  if (normalized === "anthropic-sdk") return "anthropic-sdk";
+  return "openai-compatible";
 };
 
 const parseJsonMap = (input: string | undefined): Record<string, string> => {
@@ -61,9 +68,13 @@ export const config = {
   defaultBackendTarget:
     process.env.DEFAULT_BACKEND_TARGET ?? "mock://downstream-chat-completions",
   modelMap: parseModelMap(process.env.MODEL_MAP),
+  downstreamMode: parseDownstreamMode(process.env.DOWNSTREAM_MODE),
   downstreamBaseUrl: normalizeBaseUrl(process.env.DOWNSTREAM_BASE_URL),
   downstreamApiKey: process.env.DOWNSTREAM_API_KEY,
   downstreamAuthMode: parseDownstreamAuthMode(process.env.DOWNSTREAM_AUTH_MODE),
+  anthropicBaseUrl: normalizeBaseUrl(process.env.ANTHROPIC_BASE_URL),
+  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  anthropicOauthToken: process.env.ANTHROPIC_OAUTH_TOKEN,
   downstreamTimeoutMs: parseNumber(process.env.DOWNSTREAM_TIMEOUT_MS, 30_000),
   downstreamExtraHeaders: parseJsonMap(process.env.DOWNSTREAM_EXTRA_HEADERS),
   downstreamMockFallbackEnabled: parseBoolean(

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -1,3 +1,6 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { Message } from "@anthropic-ai/sdk/resources/messages/messages";
+
 import { config } from "./config.js";
 import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
 
@@ -22,7 +25,7 @@ export type DownstreamResponse = {
 };
 
 export class DownstreamNotConfiguredError extends Error {
-  constructor(message = "LiteLLM downstream is not configured") {
+  constructor(message = "Downstream is not configured") {
     super(message);
     this.name = "DownstreamNotConfiguredError";
   }
@@ -106,7 +109,7 @@ const resolveAuthHeader = (context?: DownstreamRequestContext): string | null =>
   return `Bearer ${token}`;
 };
 
-const callLiteLLM = async (
+const callOpenAICompatible = async (
   req: ChatCompletionsRequest,
   route: RouteDecision,
   context?: DownstreamRequestContext,
@@ -151,11 +154,123 @@ const callLiteLLM = async (
   }
 };
 
+let anthropicClient: Anthropic | null = null;
+let anthropicClientKey: string | null = null;
+
+const getAnthropicClient = (): Anthropic => {
+  const token = config.anthropicOauthToken?.trim() || config.anthropicApiKey?.trim();
+  const baseURL = config.anthropicBaseUrl || config.downstreamBaseUrl || undefined;
+
+  if (!token) {
+    throw new DownstreamNotConfiguredError(
+      "ANTHROPIC_OAUTH_TOKEN or ANTHROPIC_API_KEY is required when DOWNSTREAM_MODE=anthropic-sdk",
+    );
+  }
+
+  const cacheKey = `${baseURL ?? "default"}|${token}`;
+  if (anthropicClient && anthropicClientKey === cacheKey) {
+    return anthropicClient;
+  }
+
+  anthropicClient = new Anthropic({
+    apiKey: token,
+    baseURL,
+    timeout: config.downstreamTimeoutMs,
+  });
+  anthropicClientKey = cacheKey;
+
+  return anthropicClient;
+};
+
+const toAnthropicInput = (req: ChatCompletionsRequest): {
+  system?: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+} => {
+  const system = req.messages
+    .filter((m) => m.role === "system")
+    .map((m) => m.content)
+    .join("\n\n")
+    .trim();
+
+  const messages = req.messages
+    .filter((m) => m.role !== "system")
+    .map((m) => ({
+      role: (m.role === "assistant" ? "assistant" : "user") as "user" | "assistant",
+      content: m.role === "tool" ? `[tool]\n${m.content}` : m.content,
+    }));
+
+  return { system: system || undefined, messages };
+};
+
+const toOpenAIResponse = (response: Message, model: string): DownstreamResponse => {
+  const text = response.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+
+  const inputTokens = response.usage.input_tokens;
+  const outputTokens = response.usage.output_tokens;
+
+  return {
+    id: response.id,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: text,
+        },
+        finish_reason: response.stop_reason ?? "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: inputTokens,
+      completion_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    },
+  };
+};
+
+const callAnthropicSdk = async (
+  req: ChatCompletionsRequest,
+  route: RouteDecision,
+): Promise<DownstreamResponse> => {
+  const client = getAnthropicClient();
+  const { system, messages } = toAnthropicInput(req);
+
+  try {
+    const response = await client.messages.create({
+      model: route.resolvedModel,
+      max_tokens: req.max_tokens ?? 1024,
+      temperature: req.temperature,
+      system,
+      messages,
+      stream: false,
+    });
+
+    return toOpenAIResponse(response, route.resolvedModel);
+  } catch (error) {
+    if (error instanceof Anthropic.APIError) {
+      throw new DownstreamRequestError(error.status ?? 500, error.error ?? error.message);
+    }
+
+    throw error;
+  }
+};
+
 export const callDownstream = async (
   req: ChatCompletionsRequest,
   route: RouteDecision,
   context?: DownstreamRequestContext,
 ): Promise<DownstreamResponse> => {
+  if (config.downstreamMode === "anthropic-sdk") {
+    return callAnthropicSdk(req, route);
+  }
+
   if (!config.downstreamBaseUrl) {
     if (config.downstreamMockFallbackEnabled) {
       return buildMockResponse(req, route);
@@ -166,5 +281,5 @@ export const callDownstream = async (
     );
   }
 
-  return callLiteLLM(req, route, context);
+  return callOpenAICompatible(req, route, context);
 };

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -158,22 +158,25 @@ let anthropicClient: Anthropic | null = null;
 let anthropicClientKey: string | null = null;
 
 const getAnthropicClient = (): Anthropic => {
-  const token = config.anthropicOauthToken?.trim() || config.anthropicApiKey?.trim();
+  const oauthToken = config.anthropicOauthToken?.trim();
+  const apiKey = config.anthropicApiKey?.trim();
   const baseURL = config.anthropicBaseUrl || config.downstreamBaseUrl || undefined;
 
-  if (!token) {
+  if (!oauthToken && !apiKey) {
     throw new DownstreamNotConfiguredError(
       "ANTHROPIC_OAUTH_TOKEN or ANTHROPIC_API_KEY is required when DOWNSTREAM_MODE=anthropic-sdk",
     );
   }
 
-  const cacheKey = `${baseURL ?? "default"}|${token}`;
+  const authKind = oauthToken ? "oauth" : "apiKey";
+  const authValue = oauthToken || apiKey!;
+  const cacheKey = `${baseURL ?? "default"}|${authKind}|${authValue}`;
   if (anthropicClient && anthropicClientKey === cacheKey) {
     return anthropicClient;
   }
 
   anthropicClient = new Anthropic({
-    apiKey: token,
+    ...(oauthToken ? { authToken: oauthToken } : { apiKey: apiKey! }),
     baseURL,
     timeout: config.downstreamTimeoutMs,
   });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,10 +1,17 @@
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { createApp } from "../src/app.js";
 import { config } from "../src/config.js";
 
 describe("createApp", () => {
+  beforeAll(() => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamBaseUrl = null;
+    config.downstreamMockFallbackEnabled = true;
+    config.modelMap = {};
+  });
+
   const app = createApp();
 
   it("returns health status", async () => {
@@ -18,9 +25,7 @@ describe("createApp", () => {
   });
 
   it("rejects invalid chat completions payloads", async () => {
-    const res = await request(app)
-      .post("/v1/chat/completions")
-      .send({ messages: [] });
+    const res = await request(app).post("/v1/chat/completions").send({ messages: [] });
 
     expect(res.status).toBe(400);
     expect(res.body.error.type).toBe("invalid_request_error");
@@ -61,12 +66,10 @@ describe("createApp", () => {
     config.downstreamBaseUrl = null;
     config.downstreamMockFallbackEnabled = false;
 
-    const res = await request(app)
-      .post("/v1/chat/completions")
-      .send({
-        model: "gpt-4o",
-        messages: [{ role: "user", content: "hello" }],
-      });
+    const res = await request(app).post("/v1/chat/completions").send({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hello" }],
+    });
 
     expect(res.status).toBe(503);
     expect(res.body.error.type).toBe("service_unavailable");

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -23,11 +23,13 @@ afterEach(() => {
 
 describe("callDownstream", () => {
   it("calls LiteLLM-compatible endpoint when configured", async () => {
+    const previousMode = config.downstreamMode;
     const previousBaseUrl = config.downstreamBaseUrl;
     const previousApiKey = config.downstreamApiKey;
     const previousAuthMode = config.downstreamAuthMode;
     const previousExtraHeaders = config.downstreamExtraHeaders;
 
+    config.downstreamMode = "openai-compatible";
     config.downstreamBaseUrl = "http://127.0.0.1:4000/v1";
     config.downstreamApiKey = "test-key";
     config.downstreamAuthMode = "bearer";
@@ -65,6 +67,7 @@ describe("callDownstream", () => {
 
     expect(response.model).toBe("gpt-4o-mini");
 
+    config.downstreamMode = previousMode;
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamApiKey = previousApiKey;
     config.downstreamAuthMode = previousAuthMode;
@@ -72,10 +75,12 @@ describe("callDownstream", () => {
   });
 
   it("supports x-api-key auth mode for downstream", async () => {
+    const previousMode = config.downstreamMode;
     const previousBaseUrl = config.downstreamBaseUrl;
     const previousApiKey = config.downstreamApiKey;
     const previousAuthMode = config.downstreamAuthMode;
 
+    config.downstreamMode = "openai-compatible";
     config.downstreamBaseUrl = "http://127.0.0.1:4000/v1";
     config.downstreamApiKey = "abc123";
     config.downstreamAuthMode = "x-api-key";
@@ -106,15 +111,18 @@ describe("callDownstream", () => {
     expect(headers["x-api-key"]).toBe("abc123");
     expect(headers.authorization).toBeUndefined();
 
+    config.downstreamMode = previousMode;
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamApiKey = previousApiKey;
     config.downstreamAuthMode = previousAuthMode;
   });
 
   it("supports passthrough auth mode", async () => {
+    const previousMode = config.downstreamMode;
     const previousBaseUrl = config.downstreamBaseUrl;
     const previousAuthMode = config.downstreamAuthMode;
 
+    config.downstreamMode = "openai-compatible";
     config.downstreamBaseUrl = "http://127.0.0.1:4000/v1";
     config.downstreamAuthMode = "passthrough";
 
@@ -145,14 +153,68 @@ describe("callDownstream", () => {
     const headers = requestInit.headers as Record<string, string>;
     expect(headers.authorization).toBe("Bearer passthrough-token");
 
+    config.downstreamMode = previousMode;
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamAuthMode = previousAuthMode;
   });
 
+  it("uses Anthropic SDK adapter when enabled", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_123",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "hello from claude" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const response = await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "say hi" }],
+      },
+      {
+        ...route,
+        requestedModel: "claude-sonnet-4-6",
+        resolvedModel: "claude-sonnet-4-6",
+      },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const firstArg = String(fetchSpy.mock.calls[0]?.[0]);
+    expect(firstArg).toContain("/v1/messages");
+    expect(response.model).toBe("claude-sonnet-4-6");
+    expect(response.choices[0]?.message.content).toBe("hello from claude");
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
   it("throws when not configured and fallback disabled", async () => {
+    const previousMode = config.downstreamMode;
     const previousBaseUrl = config.downstreamBaseUrl;
     const previousFallback = config.downstreamMockFallbackEnabled;
 
+    config.downstreamMode = "openai-compatible";
     config.downstreamBaseUrl = null;
     config.downstreamMockFallbackEnabled = false;
 
@@ -160,6 +222,7 @@ describe("callDownstream", () => {
       DownstreamNotConfiguredError,
     );
 
+    config.downstreamMode = previousMode;
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamMockFallbackEnabled = previousFallback;
   });

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import { config } from "../src/config.js";
 import { resolveRoute } from "../src/policy.js";
 
 describe("resolveRoute", () => {
   it("downgrades gpt-4o to gpt-4o-mini for simple prompts", () => {
+    const previousModelMap = config.modelMap;
+    config.modelMap = {};
+
     const route = resolveRoute({
       model: "gpt-4o",
       messages: [{ role: "user", content: "say hi" }],
@@ -11,9 +15,14 @@ describe("resolveRoute", () => {
 
     expect(route.resolvedModel).toBe("gpt-4o-mini");
     expect(route.routeReason).toBe("heuristic:downgrade_simple_prompt");
+
+    config.modelMap = previousModelMap;
   });
 
   it("keeps strong model for complex prompts", () => {
+    const previousModelMap = config.modelMap;
+    config.modelMap = {};
+
     const route = resolveRoute({
       model: "gpt-4o",
       messages: [{ role: "user", content: "analyze this complex problem step-by-step" }],
@@ -21,5 +30,7 @@ describe("resolveRoute", () => {
 
     expect(route.resolvedModel).toBe("gpt-4o");
     expect(route.routeReason).toBe("heuristic:keep_strong_model");
+
+    config.modelMap = previousModelMap;
   });
 });


### PR DESCRIPTION
## Summary
- add `DOWNSTREAM_MODE` with new `anthropic-sdk` option while preserving existing OpenAI-compatible/LiteLLM path
- implement Anthropic adapter using official `@anthropic-ai/sdk` and translate OpenAI chat-completions input/output to Anthropic Messages API
- add env/config for `ANTHROPIC_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_BASE_URL`
- document Anthropic OAuth setup and current limitations
- add tests for Anthropic adapter and stabilize tests against local `.env` overrides

## Why
OAuth tokens (`sk-ant-oat01-*`) in this environment require the Node SDK path; raw HTTP-style validation/requesting is not reliable for Sonnet/Opus. This provides an in-Mux provider path without depending on LiteLLM for Anthropic OAuth.

## Validation
- `npm run build`
- `npm run check`
- `npm test`

## Limitations (current)
- no streaming support in `anthropic-sdk` mode yet
- OpenAI chat role mapping is text-only (`tool` is flattened to text)