### PR TITLE
Match Claude Code OAuth path for Anthropic adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mux",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.54.0",
+        "@anthropic-ai/sdk": "^0.73.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "pino": "^9.3.2"
@@ -24,12 +24,32 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.54.0.tgz",
-      "integrity": "sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==",
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
       "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1880,6 +1900,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2647,6 +2680,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.54.0",
+    "@anthropic-ai/sdk": "^0.73.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "pino": "^9.3.2"

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -157,6 +157,8 @@ const callOpenAICompatible = async (
 let anthropicClient: Anthropic | null = null;
 let anthropicClientKey: string | null = null;
 
+const CLAUDE_CODE_VERSION = "2.1.62";
+
 const getAnthropicClient = (): Anthropic => {
   const oauthToken = config.anthropicOauthToken?.trim();
   const apiKey = config.anthropicApiKey?.trim();
@@ -176,9 +178,23 @@ const getAnthropicClient = (): Anthropic => {
   }
 
   anthropicClient = new Anthropic({
-    ...(oauthToken ? { authToken: oauthToken } : { apiKey: apiKey! }),
+    ...(oauthToken ? { authToken: oauthToken, apiKey: null } : { apiKey: apiKey! }),
     baseURL,
     timeout: config.downstreamTimeoutMs,
+    dangerouslyAllowBrowser: true,
+    defaultHeaders: oauthToken
+      ? {
+          accept: "application/json",
+          "anthropic-dangerous-direct-browser-access": "true",
+          "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14",
+          "user-agent": `claude-cli/${CLAUDE_CODE_VERSION}`,
+          "x-app": "cli",
+        }
+      : {
+          accept: "application/json",
+          "anthropic-dangerous-direct-browser-access": "true",
+          "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+        },
   });
   anthropicClientKey = cacheKey;
 
@@ -244,13 +260,20 @@ const callAnthropicSdk = async (
 ): Promise<DownstreamResponse> => {
   const client = getAnthropicClient();
   const { system, messages } = toAnthropicInput(req);
+  const isOauth = Boolean(config.anthropicOauthToken?.trim());
+  const systemBlocks = isOauth
+    ? [
+        { type: "text" as const, text: "You are Claude Code, Anthropic's official CLI for Claude." },
+        ...(system ? [{ type: "text" as const, text: system }] : []),
+      ]
+    : system;
 
   try {
     const response = await client.messages.create({
       model: route.resolvedModel,
       max_tokens: req.max_tokens ?? 1024,
       temperature: req.temperature,
-      system,
+      system: systemBlocks as any,
       messages,
       stream: false,
     });


### PR DESCRIPTION
## Summary
- upgrade Mux to @anthropic-ai/sdk 0.73.0 to match Max
- align Anthropic OAuth adapter with Claude Code-style request shape
- add Claude Code identity headers/system block needed for OAuth via AgentWeave proxy

## Why
Mux Anthropic SDK mode was close, but still failed against the AgentWeave proxy until it matched Max's real Claude Code OAuth lane more closely.

## Changes
- use newer Anthropic SDK version matching Max
- keep OAuth on authToken path
- add Claude Code beta headers / CLI identity headers
- add Claude Code system identity block for OAuth requests

## Validation
- npm run build
- npm test
- npm run check
- manual e2e validation through local Mux service against AgentWeave proxy succeeded:
  - request to /v1/chat/completions with model claude-sonnet-4-6
  - 200 OK response returned through OAuth path
