### PR TITLE
fix: return SSE chunks when chat completions stream=true

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,80 @@ const logger = pino({
   level: config.nodeEnv === "development" ? "debug" : "info",
 });
 
+function streamChatCompletion(res: express.Response, completion: {
+  id: string;
+  created: number;
+  model: string;
+  choices?: Array<{
+    message?: { role?: "assistant"; content?: string };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}) {
+  const text = completion.choices?.[0]?.message?.content ?? "";
+  const finishReason = completion.choices?.[0]?.finish_reason ?? "stop";
+
+  res.status(200);
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+
+  const writeChunk = (payload: unknown) => {
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  };
+
+  // Emit one content delta chunk. This is enough for OpenAI-compatible stream consumers.
+  writeChunk({
+    id: completion.id,
+    object: "chat.completion.chunk",
+    created: completion.created,
+    model: completion.model,
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: "assistant",
+          content: text,
+        },
+        finish_reason: null,
+      },
+    ],
+  });
+
+  // Emit final stop chunk.
+  writeChunk({
+    id: completion.id,
+    object: "chat.completion.chunk",
+    created: completion.created,
+    model: completion.model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: finishReason,
+      },
+    ],
+  });
+
+  if (completion.usage) {
+    writeChunk({
+      id: completion.id,
+      object: "chat.completion.chunk",
+      created: completion.created,
+      model: completion.model,
+      choices: [],
+      usage: completion.usage,
+    });
+  }
+
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
 export const createApp = () => {
   const app = express();
   app.use(express.json({ limit: "1mb" }));
@@ -55,6 +129,12 @@ export const createApp = () => {
       };
 
       const downstream = await callDownstream(body, route, downstreamContext);
+
+      if (body.stream) {
+        streamChatCompletion(res, downstream);
+        return;
+      }
+
       return res.status(200).json(downstream);
     } catch (error) {
       if (error instanceof DownstreamNotConfiguredError) {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -47,6 +47,22 @@ describe("createApp", () => {
     expect(res.body.choices?.[0]?.message?.content).toContain("resolved=gpt-4o-mini");
   });
 
+  it("returns OpenAI-compatible SSE chunks when stream=true", async () => {
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "say hi" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/event-stream");
+    expect(res.text).toContain("\"object\":\"chat.completion.chunk\"");
+    expect(res.text).toContain("\"delta\":{\"role\":\"assistant\"");
+    expect(res.text).toContain("data: [DONE]");
+  });
+
   it("keeps the stronger model for complex prompts", async () => {
     const res = await request(app)
       .post("/v1/chat/completions")


### PR DESCRIPTION
## Summary
- add OpenAI-compatible SSE streaming path for `POST /v1/chat/completions` when `stream=true`
- emit delta chunk, finish chunk, usage chunk, and `[DONE]`
- keep existing JSON response for non-stream requests
- add app test coverage for streaming response format

## Why
`agent-max` uses `@mariozechner/pi-ai` OpenAI-completions client in streaming mode. Mux was returning a non-stream JSON body even when `stream=true`, which made OpenAI SDK yield zero chunks and caused empty assistant text in Max/A2A/Telegram.

## Validation
- `npm test` in mux (all passing)
- local OpenAI SDK stream call now yields text delta + finish chunk instead of zero chunks
