### PR TITLE
Add first-class Anthropic model routing map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NODE_ENV=development
 # Optional static routing map. JSON object where key=requested model, value=resolved model.
 # Example: {"gpt-4o":"gpt-4o-mini"}
 MODEL_MAP={"gpt-4o":"gpt-4o-mini"}
+# Optional Anthropic-only routing map. Applied first for Claude model requests.
+# Example: {"claude-3-7-sonnet-latest":"claude-sonnet-4-5"}
+ANTHROPIC_MODEL_MAP={}
 
 # Route metadata
 DEFAULT_PROVIDER=openai-compatible

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ curl -s http://localhost:8787/v1/chat/completions \
 
 ### Current behavior
 
-- If `MODEL_MAP` includes the requested model, that mapping wins.
+- If the request is for a Claude model (`claude-*`) and `ANTHROPIC_MODEL_MAP` includes it, that Anthropic-specific mapping wins.
+- Else, if `MODEL_MAP` includes the requested model, that mapping wins.
 - Else, `gpt-4o` is downgraded to `gpt-4o-mini` for simple prompts.
 - If prompt appears complex (basic keyword heuristic), model is kept.
 - `DOWNSTREAM_MODE=openai-compatible` (default):
@@ -183,7 +184,8 @@ curl -s http://localhost:8787/v1/chat/completions \
 
 - `PORT` (default `8787`)
 - `NODE_ENV` (default `development`)
-- `MODEL_MAP` (JSON map for explicit model overrides)
+- `MODEL_MAP` (JSON map for generic explicit model overrides)
+- `ANTHROPIC_MODEL_MAP` (JSON map for Anthropic/Claude-only overrides, applied before `MODEL_MAP`)
 - `DEFAULT_PROVIDER` (metadata for logs)
 - `DEFAULT_BACKEND_TARGET` (metadata for logs)
 - `DOWNSTREAM_MODE` (`openai-compatible` default, `anthropic-sdk`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export const config = {
   defaultBackendTarget:
     process.env.DEFAULT_BACKEND_TARGET ?? "mock://downstream-chat-completions",
   modelMap: parseModelMap(process.env.MODEL_MAP),
+  anthropicModelMap: parseModelMap(process.env.ANTHROPIC_MODEL_MAP),
   downstreamMode: parseDownstreamMode(process.env.DOWNSTREAM_MODE),
   downstreamBaseUrl: normalizeBaseUrl(process.env.DOWNSTREAM_BASE_URL),
   downstreamApiKey: process.env.DOWNSTREAM_API_KEY,

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -7,8 +7,25 @@ const containsEscalationCue = (text: string): boolean => {
   return cues.some((cue) => lower.includes(cue));
 };
 
+const isAnthropicModel = (model: string): boolean => {
+  return model.toLowerCase().startsWith("claude-");
+};
+
 export const resolveRoute = (req: ChatCompletionsRequest): RouteDecision => {
   const requestedModel = req.model;
+
+  if (isAnthropicModel(requestedModel)) {
+    const anthropicMapped = config.anthropicModelMap[requestedModel];
+    if (anthropicMapped) {
+      return {
+        requestedModel,
+        resolvedModel: anthropicMapped,
+        routeReason: "config:anthropic_model_map_override",
+        provider: config.defaultProvider,
+        backendTarget: config.defaultBackendTarget,
+      };
+    }
+  }
 
   const mapped = config.modelMap[requestedModel];
   if (mapped) {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -6,7 +6,9 @@ import { resolveRoute } from "../src/policy.js";
 describe("resolveRoute", () => {
   it("downgrades gpt-4o to gpt-4o-mini for simple prompts", () => {
     const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
     config.modelMap = {};
+    config.anthropicModelMap = {};
 
     const route = resolveRoute({
       model: "gpt-4o",
@@ -17,11 +19,14 @@ describe("resolveRoute", () => {
     expect(route.routeReason).toBe("heuristic:downgrade_simple_prompt");
 
     config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
   });
 
   it("keeps strong model for complex prompts", () => {
     const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
     config.modelMap = {};
+    config.anthropicModelMap = {};
 
     const route = resolveRoute({
       model: "gpt-4o",
@@ -32,5 +37,48 @@ describe("resolveRoute", () => {
     expect(route.routeReason).toBe("heuristic:keep_strong_model");
 
     config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+  });
+
+  it("applies Anthropic-specific model map for Claude models", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    config.modelMap = {};
+    config.anthropicModelMap = {
+      "claude-3-7-sonnet-latest": "claude-sonnet-4-5",
+    };
+
+    const route = resolveRoute({
+      model: "claude-3-7-sonnet-latest",
+      messages: [{ role: "user", content: "say hi" }],
+    });
+
+    expect(route.resolvedModel).toBe("claude-sonnet-4-5");
+    expect(route.routeReason).toBe("config:anthropic_model_map_override");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+  });
+
+  it("prefers Anthropic model map over generic MODEL_MAP for Claude models", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    config.modelMap = {
+      "claude-3-7-sonnet-latest": "claude-3-5-haiku-latest",
+    };
+    config.anthropicModelMap = {
+      "claude-3-7-sonnet-latest": "claude-sonnet-4-5",
+    };
+
+    const route = resolveRoute({
+      model: "claude-3-7-sonnet-latest",
+      messages: [{ role: "user", content: "say hi" }],
+    });
+
+    expect(route.resolvedModel).toBe("claude-sonnet-4-5");
+    expect(route.routeReason).toBe("config:anthropic_model_map_override");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
   });
 });


### PR DESCRIPTION
## Summary
- add first-class Anthropic-specific routing map support via `ANTHROPIC_MODEL_MAP`
- apply Anthropic map first for Claude model requests (`claude-*`)
- keep existing `MODEL_MAP` + heuristic behavior unchanged for non-Claude requests
- add tests covering Anthropic mapping and precedence over generic model map
- document config in `.env.example` and README

## Why
Issue #17 asks for intentional Anthropic model routing policy/config while preserving the working Anthropic OAuth path.

## Validation
- `npm test`
- `npm run build`

## Notes
- No downstream transport/auth changes were made; this is policy-layer only.