### PR TITLE
feat(policy): define first Max Anthropic routing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ curl -s http://localhost:8787/v1/chat/completions \
 ### Current behavior
 
 - If the request is for a Claude model (`claude-*`) and `ANTHROPIC_MODEL_MAP` includes it, that Anthropic-specific mapping wins.
+- Else, for Max runtime Claude requests (`runtime: max` or `x-runtime: max`), Mux applies a first-pass Anthropic policy:
+  - lightweight/general chat → `claude-3-5-haiku-latest`
+  - coding/debug/troubleshooting → `claude-3-7-sonnet-latest`
+  - deeper planning/complex reasoning → `claude-opus-4-1`
 - Else, if `MODEL_MAP` includes the requested model, that mapping wins.
 - Else, `gpt-4o` is downgraded to `gpt-4o-mini` for simple prompts.
 - If prompt appears complex (basic keyword heuristic), model is kept.

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ curl -s http://localhost:8787/v1/chat/completions \
 - If the request is for a Claude model (`claude-*`) and `ANTHROPIC_MODEL_MAP` includes it, that Anthropic-specific mapping wins.
 - Else, for Max runtime Claude requests (`runtime: max` or `x-runtime: max`), Mux applies a first-pass Anthropic policy:
   - lightweight/general chat → `claude-3-5-haiku-latest`
-  - coding/debug/troubleshooting → `claude-3-7-sonnet-latest`
-  - deeper planning/complex reasoning → `claude-opus-4-1`
+  - coding/debug/troubleshooting → `claude-sonnet-4-6`
+  - deeper planning/complex reasoning → `claude-opus-4-6`
 - Else, if `MODEL_MAP` includes the requested model, that mapping wins.
 - Else, `gpt-4o` is downgraded to `gpt-4o-mini` for simple prompts.
 - If prompt appears complex (basic keyword heuristic), model is kept.

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -80,7 +80,7 @@ export const resolveRoute = (req: ChatCompletionsRequest): RouteDecision => {
       if (containsMaxDeepReasoningCue(transcript)) {
         return {
           requestedModel,
-          resolvedModel: "claude-opus-4-1",
+          resolvedModel: "claude-opus-4-6",
           routeReason: "heuristic:max_anthropic_deep_reasoning",
           provider: config.defaultProvider,
           backendTarget: config.defaultBackendTarget,
@@ -90,7 +90,7 @@ export const resolveRoute = (req: ChatCompletionsRequest): RouteDecision => {
       if (containsMaxCodingCue(transcript)) {
         return {
           requestedModel,
-          resolvedModel: "claude-3-7-sonnet-latest",
+          resolvedModel: "claude-sonnet-4-6",
           routeReason: "heuristic:max_anthropic_coding",
           provider: config.defaultProvider,
           backendTarget: config.defaultBackendTarget,

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,14 +1,62 @@
 import { config } from "./config.js";
 import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
 
-const containsEscalationCue = (text: string): boolean => {
-  const cues = ["deep", "complex", "reason", "step-by-step", "analyze", "hard"];
+const containsAny = (text: string, cues: string[]): boolean => {
   const lower = text.toLowerCase();
   return cues.some((cue) => lower.includes(cue));
 };
 
+const containsEscalationCue = (text: string): boolean => {
+  const cues = ["deep", "complex", "reason", "step-by-step", "analyze", "hard"];
+  return containsAny(text, cues);
+};
+
+const containsMaxCodingCue = (text: string): boolean => {
+  const cues = [
+    "code",
+    "coding",
+    "debug",
+    "bug",
+    "stack trace",
+    "error",
+    "typescript",
+    "javascript",
+    "python",
+    "fix this",
+    "refactor",
+    "troubleshoot",
+    "terminal",
+    "cli",
+  ];
+  return containsAny(text, cues);
+};
+
+const containsMaxDeepReasoningCue = (text: string): boolean => {
+  const cues = [
+    "deep",
+    "complex",
+    "tradeoff",
+    "trade-off",
+    "long-term",
+    "strategy",
+    "architecture",
+    "step-by-step",
+    "reason",
+    "analyze",
+    "plan",
+    "roadmap",
+  ];
+  return containsAny(text, cues);
+};
+
 const isAnthropicModel = (model: string): boolean => {
   return model.toLowerCase().startsWith("claude-");
+};
+
+const isMaxRuntime = (runtime: string | undefined): boolean => {
+  if (!runtime) return false;
+  const normalized = runtime.toLowerCase();
+  return normalized === "max" || normalized === "pi-mono" || normalized === "pimono";
 };
 
 export const resolveRoute = (req: ChatCompletionsRequest): RouteDecision => {
@@ -21,6 +69,38 @@ export const resolveRoute = (req: ChatCompletionsRequest): RouteDecision => {
         requestedModel,
         resolvedModel: anthropicMapped,
         routeReason: "config:anthropic_model_map_override",
+        provider: config.defaultProvider,
+        backendTarget: config.defaultBackendTarget,
+      };
+    }
+
+    if (isMaxRuntime(req.runtime)) {
+      const transcript = req.messages.map((m) => m.content).join("\n");
+
+      if (containsMaxDeepReasoningCue(transcript)) {
+        return {
+          requestedModel,
+          resolvedModel: "claude-opus-4-1",
+          routeReason: "heuristic:max_anthropic_deep_reasoning",
+          provider: config.defaultProvider,
+          backendTarget: config.defaultBackendTarget,
+        };
+      }
+
+      if (containsMaxCodingCue(transcript)) {
+        return {
+          requestedModel,
+          resolvedModel: "claude-3-7-sonnet-latest",
+          routeReason: "heuristic:max_anthropic_coding",
+          provider: config.defaultProvider,
+          backendTarget: config.defaultBackendTarget,
+        };
+      }
+
+      return {
+        requestedModel,
+        resolvedModel: "claude-3-5-haiku-latest",
+        routeReason: "heuristic:max_anthropic_lightweight",
         provider: config.defaultProvider,
         backendTarget: config.defaultBackendTarget,
       };

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -81,4 +81,82 @@ describe("resolveRoute", () => {
     config.modelMap = previousModelMap;
     config.anthropicModelMap = previousAnthropicModelMap;
   });
+
+  it("routes Max lightweight Claude prompts to Haiku", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    config.modelMap = {};
+    config.anthropicModelMap = {};
+
+    const route = resolveRoute({
+      model: "claude-3-7-sonnet-latest",
+      runtime: "max",
+      messages: [{ role: "user", content: "give me a quick summary" }],
+    });
+
+    expect(route.resolvedModel).toBe("claude-3-5-haiku-latest");
+    expect(route.routeReason).toBe("heuristic:max_anthropic_lightweight");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+  });
+
+  it("routes Max coding/debug Claude prompts to Sonnet", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    config.modelMap = {};
+    config.anthropicModelMap = {};
+
+    const route = resolveRoute({
+      model: "claude-3-5-haiku-latest",
+      runtime: "max",
+      messages: [{ role: "user", content: "debug this TypeScript stack trace" }],
+    });
+
+    expect(route.resolvedModel).toBe("claude-3-7-sonnet-latest");
+    expect(route.routeReason).toBe("heuristic:max_anthropic_coding");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+  });
+
+  it("routes Max deep-reasoning Claude prompts to Opus", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    config.modelMap = {};
+    config.anthropicModelMap = {};
+
+    const route = resolveRoute({
+      model: "claude-3-7-sonnet-latest",
+      runtime: "max",
+      messages: [{ role: "user", content: "analyze architecture tradeoffs and make a long-term roadmap" }],
+    });
+
+    expect(route.resolvedModel).toBe("claude-opus-4-1");
+    expect(route.routeReason).toBe("heuristic:max_anthropic_deep_reasoning");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+  });
+
+  it("keeps Anthropic model-map override ahead of Max heuristics", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    config.modelMap = {};
+    config.anthropicModelMap = {
+      "claude-3-7-sonnet-latest": "claude-sonnet-4-5",
+    };
+
+    const route = resolveRoute({
+      model: "claude-3-7-sonnet-latest",
+      runtime: "max",
+      messages: [{ role: "user", content: "analyze architecture tradeoffs" }],
+    });
+
+    expect(route.resolvedModel).toBe("claude-sonnet-4-5");
+    expect(route.routeReason).toBe("config:anthropic_model_map_override");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+  });
 });

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -45,7 +45,7 @@ describe("resolveRoute", () => {
     const previousAnthropicModelMap = config.anthropicModelMap;
     config.modelMap = {};
     config.anthropicModelMap = {
-      "claude-3-7-sonnet-latest": "claude-sonnet-4-5",
+      "claude-3-7-sonnet-latest": "claude-sonnet-4-6",
     };
 
     const route = resolveRoute({
@@ -53,7 +53,7 @@ describe("resolveRoute", () => {
       messages: [{ role: "user", content: "say hi" }],
     });
 
-    expect(route.resolvedModel).toBe("claude-sonnet-4-5");
+    expect(route.resolvedModel).toBe("claude-sonnet-4-6");
     expect(route.routeReason).toBe("config:anthropic_model_map_override");
 
     config.modelMap = previousModelMap;
@@ -67,7 +67,7 @@ describe("resolveRoute", () => {
       "claude-3-7-sonnet-latest": "claude-3-5-haiku-latest",
     };
     config.anthropicModelMap = {
-      "claude-3-7-sonnet-latest": "claude-sonnet-4-5",
+      "claude-3-7-sonnet-latest": "claude-sonnet-4-6",
     };
 
     const route = resolveRoute({
@@ -75,7 +75,7 @@ describe("resolveRoute", () => {
       messages: [{ role: "user", content: "say hi" }],
     });
 
-    expect(route.resolvedModel).toBe("claude-sonnet-4-5");
+    expect(route.resolvedModel).toBe("claude-sonnet-4-6");
     expect(route.routeReason).toBe("config:anthropic_model_map_override");
 
     config.modelMap = previousModelMap;
@@ -113,7 +113,7 @@ describe("resolveRoute", () => {
       messages: [{ role: "user", content: "debug this TypeScript stack trace" }],
     });
 
-    expect(route.resolvedModel).toBe("claude-3-7-sonnet-latest");
+    expect(route.resolvedModel).toBe("claude-sonnet-4-6");
     expect(route.routeReason).toBe("heuristic:max_anthropic_coding");
 
     config.modelMap = previousModelMap;
@@ -132,7 +132,7 @@ describe("resolveRoute", () => {
       messages: [{ role: "user", content: "analyze architecture tradeoffs and make a long-term roadmap" }],
     });
 
-    expect(route.resolvedModel).toBe("claude-opus-4-1");
+    expect(route.resolvedModel).toBe("claude-opus-4-6");
     expect(route.routeReason).toBe("heuristic:max_anthropic_deep_reasoning");
 
     config.modelMap = previousModelMap;
@@ -144,7 +144,7 @@ describe("resolveRoute", () => {
     const previousAnthropicModelMap = config.anthropicModelMap;
     config.modelMap = {};
     config.anthropicModelMap = {
-      "claude-3-7-sonnet-latest": "claude-sonnet-4-5",
+      "claude-3-7-sonnet-latest": "claude-sonnet-4-6",
     };
 
     const route = resolveRoute({
@@ -153,7 +153,7 @@ describe("resolveRoute", () => {
       messages: [{ role: "user", content: "analyze architecture tradeoffs" }],
     });
 
-    expect(route.resolvedModel).toBe("claude-sonnet-4-5");
+    expect(route.resolvedModel).toBe("claude-sonnet-4-6");
     expect(route.routeReason).toBe("config:anthropic_model_map_override");
 
     config.modelMap = previousModelMap;


### PR DESCRIPTION
## Summary
Implements the first practical Anthropic routing policy for Max in Mux with a tight heuristic-based approach in `src/policy.ts`.

## Routing behavior (Max + Claude only, when no `ANTHROPIC_MODEL_MAP` override exists)
- Lightweight/general prompts -> `claude-3-5-haiku-latest`
- Coding/debug/troubleshooting prompts -> `claude-3-7-sonnet-latest`
- Deep planning/complex reasoning prompts -> `claude-opus-4-1`

## Precedence
1. `ANTHROPIC_MODEL_MAP` (Claude-only explicit override)
2. Max Anthropic heuristic policy
3. Existing generic `MODEL_MAP` and other heuristics/defaults

## Changes
- `src/policy.ts`
  - Added Max runtime detection (`max`, `pi-mono`, `pimono`)
  - Added Claude-only Max routing heuristics and route reasons
  - Kept current non-Max and non-Claude behavior intact
- `tests/policy.test.ts`
  - Added coverage for Max lightweight/coding/deep-reasoning paths
  - Added coverage for precedence: `ANTHROPIC_MODEL_MAP` still wins
- `README.md`
  - Documented the new Max Anthropic first-pass policy in Current behavior

## Validation
- `npm test` passes (19 tests)

Closes #19
