### PR TITLE
fix(downstream): pass images through to Anthropic + diagnostic logging

### DIFF
--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -1,8 +1,16 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { Message } from "@anthropic-ai/sdk/resources/messages/messages";
+import pino from "pino";
 
 import { config } from "./config.js";
 import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
+
+export const downstreamLogger = pino({
+  level: config.nodeEnv === "development" ? "debug" : "info",
+  name: "mux.downstream",
+});
+
+const DEFAULT_ANTHROPIC_MAX_TOKENS = 4096;
 
 export type DownstreamResponse = {
   id: string;
@@ -157,6 +165,14 @@ const callOpenAICompatible = async (
 let anthropicClient: Anthropic | null = null;
 let anthropicClientKey: string | null = null;
 
+// Test-only: drop the cached Anthropic client so a fresh one is constructed
+// on the next call. Needed because the SDK captures a `fetch` reference at
+// construction time, which survives `vi.restoreAllMocks()`.
+export const __resetAnthropicClientForTests = () => {
+  anthropicClient = null;
+  anthropicClientKey = null;
+};
+
 const CLAUDE_CODE_VERSION = "2.1.62";
 
 const stringifyUnknown = (value: unknown): string => {
@@ -169,30 +185,100 @@ const stringifyUnknown = (value: unknown): string => {
   }
 };
 
-const normalizeContentToText = (content: unknown): string => {
-  if (typeof content === "string") return content;
+// Anthropic content block types we emit. Kept as plain object literals so we
+// don't couple the rest of the file to SDK internals.
+type AnthropicTextBlock = { type: "text"; text: string };
+type AnthropicImageBlock = {
+  type: "image";
+  source:
+    | { type: "base64"; media_type: string; data: string }
+    | { type: "url"; url: string };
+};
+type AnthropicContentBlock = AnthropicTextBlock | AnthropicImageBlock;
+
+const DATA_URL_RE = /^data:([^;,]+);base64,(.*)$/;
+
+const parseImageUrl = (url: unknown): AnthropicImageBlock | null => {
+  if (typeof url !== "string" || url.length === 0) return null;
+  const match = url.match(DATA_URL_RE);
+  if (match) {
+    return {
+      type: "image",
+      source: { type: "base64", media_type: match[1]!, data: match[2]! },
+    };
+  }
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    return { type: "image", source: { type: "url", url } };
+  }
+  return null;
+};
+
+const partToBlock = (part: unknown): AnthropicContentBlock | null => {
+  if (typeof part === "string") {
+    return part.length > 0 ? { type: "text", text: part } : null;
+  }
+  if (!part || typeof part !== "object") return null;
+
+  const p = part as Record<string, unknown>;
+
+  // OpenAI-style image_url part: { type: "image_url", image_url: { url } }
+  if (p.type === "image_url") {
+    const imageUrl = p.image_url;
+    if (typeof imageUrl === "string") {
+      return parseImageUrl(imageUrl);
+    }
+    if (imageUrl && typeof imageUrl === "object") {
+      return parseImageUrl((imageUrl as Record<string, unknown>).url);
+    }
+    return null;
+  }
+
+  // Native Anthropic image block passthrough.
+  if (p.type === "image" && p.source && typeof p.source === "object") {
+    return { type: "image", source: p.source as AnthropicImageBlock["source"] };
+  }
+
+  // Text-like parts.
+  if (p.type === "text" && typeof p.text === "string") {
+    return p.text.length > 0 ? { type: "text", text: p.text } : null;
+  }
+  if (p.type === "input_text" && typeof p.text === "string") {
+    return p.text.length > 0 ? { type: "text", text: p.text } : null;
+  }
+  if (typeof p.text === "string") {
+    return p.text.length > 0 ? { type: "text", text: p.text } : null;
+  }
+  if (typeof p.content === "string") {
+    return p.content.length > 0 ? { type: "text", text: p.content } : null;
+  }
+
+  return null;
+};
+
+const normalizeContentToBlocks = (content: unknown): AnthropicContentBlock[] => {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "text", text: content }] : [];
+  }
   if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (typeof part === "string") return part;
-        if (part && typeof part === "object") {
-          const p = part as Record<string, unknown>;
-          if (typeof p.text === "string") return p.text;
-          if (typeof p.content === "string") return p.content;
-          if (p.type === "input_text" && typeof p.text === "string") return p.text;
-          if (p.type === "text" && typeof p.text === "string") return p.text;
-        }
-        return stringifyUnknown(part);
-      })
-      .filter(Boolean)
-      .join("\n");
+    const blocks: AnthropicContentBlock[] = [];
+    for (const part of content) {
+      const block = partToBlock(part);
+      if (block) blocks.push(block);
+    }
+    return blocks;
   }
   if (content && typeof content === "object") {
-    const c = content as Record<string, unknown>;
-    if (typeof c.text === "string") return c.text;
-    if (typeof c.content === "string") return c.content;
+    const block = partToBlock(content);
+    if (block) return [block];
   }
-  return stringifyUnknown(content);
+  return [];
+};
+
+const normalizeContentToText = (content: unknown): string => {
+  return normalizeContentToBlocks(content)
+    .filter((b): b is AnthropicTextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
 };
 
 const getAnthropicClient = (): Anthropic => {
@@ -237,9 +323,14 @@ const getAnthropicClient = (): Anthropic => {
   return anthropicClient;
 };
 
-const toAnthropicInput = (req: ChatCompletionsRequest): {
+export type AnthropicInputMessage = {
+  role: "user" | "assistant";
+  content: AnthropicContentBlock[];
+};
+
+export const toAnthropicInput = (req: ChatCompletionsRequest): {
   system?: string;
-  messages: Array<{ role: "user" | "assistant"; content: Array<{ type: "text"; text: string }> }>;
+  messages: AnthropicInputMessage[];
 } => {
   const system = req.messages
     .filter((m) => m.role === "system")
@@ -247,35 +338,45 @@ const toAnthropicInput = (req: ChatCompletionsRequest): {
     .join("\n\n")
     .trim();
 
-  const messages = req.messages
-    .filter((m) => m.role !== "system")
-    .map((m) => {
-      const text = normalizeContentToText(m.content).trim();
-      return {
-        role: (m.role === "assistant" ? "assistant" : "user") as "user" | "assistant",
-        text: m.role === "tool" ? `[tool]\n${text}` : text,
-      };
-    })
-    .filter((m) => m.text.length > 0)
-    .map((m) => ({
-      role: m.role,
-      content: [
-        {
-          type: "text" as const,
-          text: m.text,
-        },
-      ],
-    }));
+  const messages: AnthropicInputMessage[] = [];
+  for (const m of req.messages) {
+    if (m.role === "system") continue;
+    const role: "user" | "assistant" = m.role === "assistant" ? "assistant" : "user";
+    const blocks = normalizeContentToBlocks(m.content);
+
+    // For tool results, prefix the first text block with a [tool] marker so the
+    // downstream model still sees that the content came from a tool.
+    if (m.role === "tool") {
+      const firstText = blocks.find((b) => b.type === "text") as AnthropicTextBlock | undefined;
+      if (firstText) {
+        firstText.text = `[tool]\n${firstText.text}`;
+      } else {
+        blocks.unshift({ type: "text", text: "[tool]" });
+      }
+    }
+
+    if (blocks.length === 0) continue;
+    messages.push({ role, content: blocks });
+  }
 
   return { system: system || undefined, messages };
 };
 
-const toOpenAIResponse = (response: Message, model: string): DownstreamResponse => {
-  const text = response.content
-    .filter((block) => block.type === "text")
-    .map((block) => block.text)
-    .join("\n")
-    .trim();
+export const toOpenAIResponse = (response: Message, model: string): DownstreamResponse => {
+  const textBlocks = response.content.filter((block) => block.type === "text") as Array<{
+    type: "text";
+    text: string;
+  }>;
+  const joined = textBlocks.map((block) => block.text).join("\n").trim();
+
+  // When nothing survives the filter, surface a synthetic marker so clients
+  // don't render `(no response)`. This makes regressions loud instead of silent.
+  const content =
+    joined.length > 0
+      ? joined
+      : `[empty response from downstream — stop_reason=${
+          response.stop_reason ?? "unknown"
+        }, blocks=${response.content.map((b) => b.type).join(",") || "none"}]`;
 
   const inputTokens = response.usage.input_tokens;
   const outputTokens = response.usage.output_tokens;
@@ -290,7 +391,7 @@ const toOpenAIResponse = (response: Message, model: string): DownstreamResponse 
         index: 0,
         message: {
           role: "assistant",
-          content: text,
+          content,
         },
         finish_reason: response.stop_reason ?? "stop",
       },
@@ -302,6 +403,15 @@ const toOpenAIResponse = (response: Message, model: string): DownstreamResponse 
     },
   };
 };
+
+const summarizeMessagesForLog = (messages: AnthropicInputMessage[]) =>
+  messages.map((m, index) => {
+    const textLength = m.content
+      .filter((b): b is AnthropicTextBlock => b.type === "text")
+      .reduce((sum, b) => sum + b.text.length, 0);
+    const imageCount = m.content.filter((b) => b.type === "image").length;
+    return { index, role: m.role, textLength, imageCount, blockCount: m.content.length };
+  });
 
 const callAnthropicSdk = async (
   req: ChatCompletionsRequest,
@@ -317,22 +427,79 @@ const callAnthropicSdk = async (
       ]
     : system;
 
+  const maxTokens = req.max_tokens ?? DEFAULT_ANTHROPIC_MAX_TOKENS;
+  const systemLength = Array.isArray(systemBlocks)
+    ? systemBlocks.reduce((sum, b) => sum + b.text.length, 0)
+    : (systemBlocks?.length ?? 0);
+
+  downstreamLogger.info({
+    event: "mux.anthropic_request",
+    requestedModel: route.requestedModel,
+    resolvedModel: route.resolvedModel,
+    maxTokens,
+    systemLength,
+    messageCount: messages.length,
+    rawMessageCount: req.messages.length,
+    rawRoles: req.messages.map((m) => m.role),
+    messages: summarizeMessagesForLog(messages),
+  });
+
   try {
     const response = await client.messages.create({
       model: route.resolvedModel,
-      max_tokens: req.max_tokens ?? 1024,
+      max_tokens: maxTokens,
       temperature: req.temperature,
       system: systemBlocks as any,
-      messages,
+      messages: messages as any,
       stream: false,
     });
+
+    const textBlocks = response.content.filter((b) => b.type === "text") as Array<{
+      type: "text";
+      text: string;
+    }>;
+    const joinedTextLength = textBlocks.reduce((sum, b) => sum + b.text.length, 0);
+    const blockTypes = response.content.map((b) => b.type);
+    const empty = textBlocks.length === 0 || joinedTextLength === 0;
+
+    const respEvent = {
+      event: "mux.anthropic_response",
+      resolvedModel: route.resolvedModel,
+      stopReason: response.stop_reason ?? null,
+      stopSequence: response.stop_sequence ?? null,
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+      blockCount: response.content.length,
+      blockTypes,
+      textBlockCount: textBlocks.length,
+      joinedTextLength,
+      empty,
+    };
+    if (empty) {
+      downstreamLogger.warn(respEvent);
+    } else {
+      downstreamLogger.info(respEvent);
+    }
 
     return toOpenAIResponse(response, route.resolvedModel);
   } catch (error) {
     if (error instanceof Anthropic.APIError) {
+      downstreamLogger.error({
+        event: "mux.anthropic_api_error",
+        resolvedModel: route.resolvedModel,
+        status: error.status ?? null,
+        name: error.name,
+        message: error.message,
+        body: error.error ?? null,
+      });
       throw new DownstreamRequestError(error.status ?? 500, error.error ?? error.message);
     }
 
+    downstreamLogger.error({
+      event: "mux.anthropic_unknown_error",
+      resolvedModel: route.resolvedModel,
+      err: error instanceof Error ? { name: error.name, message: error.message } : String(error),
+    });
     throw error;
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 export type ChatMessage = {
   role: "system" | "user" | "assistant" | "tool";
-  content: string;
+  // Upstream clients (OpenAI-style, pi-ai, etc.) send either a plain string
+  // or an array of content parts (text, image_url, native Anthropic blocks).
+  // We normalize downstream.
+  content: unknown;
 };
 
 export type ChatCompletionsRequest = {

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { config } from "../src/config.js";
-import { callDownstream, DownstreamNotConfiguredError } from "../src/downstream.js";
+import {
+  __resetAnthropicClientForTests,
+  callDownstream,
+  DownstreamNotConfiguredError,
+  downstreamLogger,
+  toAnthropicInput,
+  toOpenAIResponse,
+} from "../src/downstream.js";
 import type { ChatCompletionsRequest, RouteDecision } from "../src/types.js";
 
 const requestPayload: ChatCompletionsRequest = {
@@ -19,6 +26,7 @@ const route: RouteDecision = {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  __resetAnthropicClientForTests();
 });
 
 describe("callDownstream", () => {
@@ -209,6 +217,250 @@ describe("callDownstream", () => {
     config.anthropicBaseUrl = previousAnthropicBaseUrl;
   });
 
+  it("forwards req.max_tokens to Anthropic when set", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_123",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 8192,
+      },
+      { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+    expect(body.max_tokens).toBe(8192);
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
+  it("defaults Anthropic max_tokens to 4096 when request omits it", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_123",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+    expect(body.max_tokens).toBe(4096);
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
+  it("logs mux.anthropic_request and mux.anthropic_response on success", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_123",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "hello" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 3, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const infoSpy = vi.spyOn(downstreamLogger, "info");
+
+    await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const events = infoSpy.mock.calls.map((c) => (c[0] as { event: string }).event);
+    expect(events).toContain("mux.anthropic_request");
+    expect(events).toContain("mux.anthropic_response");
+
+    const reqEvent = infoSpy.mock.calls.find(
+      (c) => (c[0] as { event: string }).event === "mux.anthropic_request",
+    )?.[0] as Record<string, unknown>;
+    expect(reqEvent.messageCount).toBe(1);
+    expect(reqEvent.maxTokens).toBe(4096);
+
+    const respEvent = infoSpy.mock.calls.find(
+      (c) => (c[0] as { event: string }).event === "mux.anthropic_response",
+    )?.[0] as Record<string, unknown>;
+    expect(respEvent.stopReason).toBe("end_turn");
+    expect(respEvent.textBlockCount).toBe(1);
+    expect(respEvent.joinedTextLength).toBe(5);
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
+  it("warns with empty:true when Anthropic returns no text blocks", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_empty",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [],
+          stop_reason: "max_tokens",
+          stop_sequence: null,
+          usage: { input_tokens: 100, output_tokens: 1024 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const warnSpy = vi.spyOn(downstreamLogger, "warn");
+
+    const response = await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const warnEvents = warnSpy.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const emptyEvent = warnEvents.find((e) => e.event === "mux.anthropic_response");
+    expect(emptyEvent).toBeDefined();
+    expect(emptyEvent?.empty).toBe(true);
+    expect(emptyEvent?.stopReason).toBe("max_tokens");
+
+    // Surface synthetic marker to the client instead of plain empty string.
+    expect(response.choices[0]?.message.content).toContain("[empty response");
+    expect(response.choices[0]?.message.content).toContain("max_tokens");
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
+  it("logs mux.anthropic_api_error on Anthropic 4xx", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "invalid_request_error", message: "bad image" },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const errorSpy = vi.spyOn(downstreamLogger, "error");
+
+    await expect(
+      callDownstream(
+        {
+          model: "claude-sonnet-4-6",
+          messages: [{ role: "user", content: "hi" }],
+        },
+        { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+      ),
+    ).rejects.toBeDefined();
+
+    const events = errorSpy.mock.calls.map((c) => (c[0] as { event: string }).event);
+    expect(events).toContain("mux.anthropic_api_error");
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
   it("throws when not configured and fallback disabled", async () => {
     const previousMode = config.downstreamMode;
     const previousBaseUrl = config.downstreamBaseUrl;
@@ -225,5 +477,149 @@ describe("callDownstream", () => {
     config.downstreamMode = previousMode;
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamMockFallbackEnabled = previousFallback;
+  });
+});
+
+describe("toAnthropicInput", () => {
+  it("converts OpenAI image_url data URL into an Anthropic base64 image block", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/jpeg;base64,ABCDEF" },
+            },
+          ],
+        } as unknown as ChatCompletionsRequest["messages"][number],
+      ],
+    });
+
+    expect(messages).toHaveLength(1);
+    const blocks = messages[0]!.content;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ type: "text", text: "What is in this image?" });
+    expect(blocks[1]).toEqual({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: "ABCDEF" },
+    });
+  });
+
+  it("converts OpenAI image_url https URL into an Anthropic url image block", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/pic.png" },
+            },
+          ],
+        } as unknown as ChatCompletionsRequest["messages"][number],
+      ],
+    });
+
+    expect(messages[0]!.content).toEqual([
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.com/pic.png" },
+      },
+    ]);
+  });
+
+  it("passes through Anthropic-native image blocks unchanged", () => {
+    const nativeBlock = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "XYZ" },
+    };
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        {
+          role: "user",
+          content: [nativeBlock],
+        } as unknown as ChatCompletionsRequest["messages"][number],
+      ],
+    });
+
+    expect(messages[0]!.content).toEqual([nativeBlock]);
+  });
+
+  it("preserves a plain text message as a text block", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ]);
+  });
+
+  it("keeps an image-only user message (no text) in the output", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,ZZZ" },
+            },
+          ],
+        } as unknown as ChatCompletionsRequest["messages"][number],
+      ],
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.content[0]!.type).toBe("image");
+  });
+});
+
+describe("toOpenAIResponse", () => {
+  it("returns joined text from text blocks", () => {
+    const response = toOpenAIResponse(
+      {
+        id: "msg_1",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "text", text: "world" },
+        ],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 2 },
+      } as unknown as Parameters<typeof toOpenAIResponse>[0],
+      "claude-sonnet-4-6",
+    );
+
+    expect(response.choices[0]!.message.content).toBe("hello\nworld");
+  });
+
+  it("surfaces a synthetic empty-response marker when no text blocks survive", () => {
+    const response = toOpenAIResponse(
+      {
+        id: "msg_empty",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [],
+        stop_reason: "max_tokens",
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 1024 },
+      } as unknown as Parameters<typeof toOpenAIResponse>[0],
+      "claude-sonnet-4-6",
+    );
+
+    expect(response.choices[0]!.message.content).toContain("[empty response");
+    expect(response.choices[0]!.message.content).toContain("max_tokens");
   });
 });


### PR DESCRIPTION
Resolves #22.

## Summary
- OpenAI-style `image_url` content parts (data URLs and https URLs) and native Anthropic `image` blocks now pass through `toAnthropicInput` as real content blocks instead of being `JSON.stringify`'d into a single text block.
- Default `max_tokens` on the Anthropic path raised from 1024 → 4096 (still forwards `req.max_tokens` when set).
- New `downstreamLogger` emits structured `mux.anthropic_request` / `mux.anthropic_response` / `mux.anthropic_api_error` / `mux.anthropic_unknown_error` events. Empty responses log at **warn** with `empty: true` so they're loud in logs.
- `toOpenAIResponse` surfaces a synthetic `[empty response from downstream — stop_reason=X, blocks=Y]` marker when no text blocks survive, so future regressions don't look like `(no response)` to clients.
- `ChatMessage.content` widened from `string` to `unknown` to match reality (clients send arrays of parts).

## Test plan
- [x] `npm run check` — tsc clean
- [x] `npm test` — 31/31 passing (12 new)
  - `toAnthropicInput`: base64 data URL, https URL, native image block, plain text, image-only
  - `toOpenAIResponse`: joined text, synthetic empty marker
  - `callDownstream` / Anthropic adapter: `max_tokens` forwarding, 4096 default, `mux.anthropic_request` + `mux.anthropic_response` events, `empty:true` warn event, `mux.anthropic_api_error` event
- [ ] Deploy to NAS mux service, reproduce an image-bearing Telegram prompt through agent-max, capture `mux.anthropic_request` / `mux.anthropic_response` log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)