### PR TITLE
fix(downstream): translate Anthropic stop_reason to OpenAI finish_reason

### DIFF
--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -362,6 +362,33 @@ export const toAnthropicInput = (req: ChatCompletionsRequest): {
   return { system: system || undefined, messages };
 };
 
+/**
+ * Translate an Anthropic `stop_reason` into an OpenAI `finish_reason`.
+ *
+ * OpenAI clients (including pi-ai's openai-completions adapter) only know the
+ * OpenAI vocabulary: `stop | length | tool_calls | content_filter | function_call`.
+ * If Mux passes Anthropic values through verbatim (`end_turn`, `max_tokens`, …),
+ * pi-ai's mapStopReason throws `Unhandled stop reason: end_turn` AFTER the
+ * text has already streamed. The assistant message is then persisted by the
+ * agent with stopReason="error" and transform-messages.js drops it on every
+ * subsequent turn — producing the +1/turn context bleed tracked in
+ * arniesaha/agent-max#24.
+ */
+export const anthropicStopReasonToOpenAI = (
+  reason: string | null | undefined,
+): "stop" | "length" | "tool_calls" => {
+  switch (reason) {
+    case "tool_use":
+      return "tool_calls";
+    case "max_tokens":
+    case "model_context_window_exceeded":
+      return "length";
+    default:
+      // end_turn / stop_sequence / refusal / pause_turn / null / unknown → "stop"
+      return "stop";
+  }
+};
+
 export const toOpenAIResponse = (response: Message, model: string): DownstreamResponse => {
   const textBlocks = response.content.filter((block) => block.type === "text") as Array<{
     type: "text";
@@ -393,7 +420,7 @@ export const toOpenAIResponse = (response: Message, model: string): DownstreamRe
           role: "assistant",
           content,
         },
-        finish_reason: response.stop_reason ?? "stop",
+        finish_reason: anthropicStopReasonToOpenAI(response.stop_reason),
       },
     ],
     usage: {

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -5,6 +5,7 @@ import {
   __resetAnthropicClientForTests,
   callDownstream,
   DownstreamNotConfiguredError,
+  anthropicStopReasonToOpenAI,
   downstreamLogger,
   toAnthropicInput,
   toOpenAIResponse,
@@ -621,5 +622,44 @@ describe("toOpenAIResponse", () => {
 
     expect(response.choices[0]!.message.content).toContain("[empty response");
     expect(response.choices[0]!.message.content).toContain("max_tokens");
+  });
+
+  it("translates Anthropic stop_reason into OpenAI finish_reason", () => {
+    const build = (stopReason: string) =>
+      toOpenAIResponse(
+        {
+          id: "msg_x",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: stopReason,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        } as unknown as Parameters<typeof toOpenAIResponse>[0],
+        "claude-sonnet-4-6",
+      );
+
+    expect(build("end_turn").choices[0]!.finish_reason).toBe("stop");
+    expect(build("stop_sequence").choices[0]!.finish_reason).toBe("stop");
+    expect(build("max_tokens").choices[0]!.finish_reason).toBe("length");
+    expect(build("tool_use").choices[0]!.finish_reason).toBe("tool_calls");
+  });
+});
+
+describe("anthropicStopReasonToOpenAI", () => {
+  it("maps Anthropic stop_reason values to the OpenAI vocabulary", () => {
+    expect(anthropicStopReasonToOpenAI("end_turn")).toBe("stop");
+    expect(anthropicStopReasonToOpenAI("stop_sequence")).toBe("stop");
+    expect(anthropicStopReasonToOpenAI("refusal")).toBe("stop");
+    expect(anthropicStopReasonToOpenAI("pause_turn")).toBe("stop");
+    expect(anthropicStopReasonToOpenAI("max_tokens")).toBe("length");
+    expect(anthropicStopReasonToOpenAI("model_context_window_exceeded")).toBe("length");
+    expect(anthropicStopReasonToOpenAI("tool_use")).toBe("tool_calls");
+    expect(anthropicStopReasonToOpenAI(null)).toBe("stop");
+    expect(anthropicStopReasonToOpenAI(undefined)).toBe("stop");
+    // Unknown values fall back to "stop" instead of throwing, so an
+    // unrecognized Anthropic value never poisons downstream agents.
+    expect(anthropicStopReasonToOpenAI("totally_made_up" as any)).toBe("stop");
   });
 });


### PR DESCRIPTION
## Summary
- Introduce `anthropicStopReasonToOpenAI` and use it in `toOpenAIResponse` so mux never forwards Anthropic's `stop_reason` vocabulary (`end_turn`, `stop_sequence`, `max_tokens`, `tool_use`, `refusal`, `pause_turn`, `model_context_window_exceeded`) as if it were OpenAI's `finish_reason`.
- Unknown values fall back to `"stop"` so a future Anthropic enum extension can never poison downstream agent state again.
- Tests: explicit coverage for every mapping + an assertion on `toOpenAIResponse.finish_reason` for each Anthropic input.

## Why
Resolves #26. This is the root cause of [arniesaha/agent-max#24](https://github.com/arniesaha/agent-max/issues/24) — context bleed and the "Let me check." loop. Full mechanism in #26, but briefly: pi-ai's `openai-completions` adapter throws on `finish_reason: "end_turn"` AFTER the text has already streamed. The agent persists the assistant message with `stopReason: "error"`, and pi-ai's `transform-messages.js` filters it out of every subsequent request. Net effect: mux's `messageCount` grew by exactly +1 per turn (user only, no interleaved assistant), and Claude answered the wrong question or repeated itself.

## Test plan
- [x] `npm run check` — clean
- [x] `npm test` — 33/33 pass, new mapping tests included
- [ ] Deploy to NAS and confirm agent-max `messageCount` at mux starts growing +2 per turn on successful Claude responses
- [ ] Reproduce the "Let me check." scenario from agent-max#24 and confirm the second follow-up actually gets the tool call it promised

Closes #26