### PR TITLE
feat(downstream): forward tools and tool_use/tool_result through Anthropic

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,12 +15,22 @@ const logger = pino({
   level: config.nodeEnv === "development" ? "debug" : "info",
 });
 
+type StreamToolCall = {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+};
+
 function streamChatCompletion(res: express.Response, completion: {
   id: string;
   created: number;
   model: string;
   choices?: Array<{
-    message?: { role?: "assistant"; content?: string };
+    message?: {
+      role?: "assistant";
+      content?: string | null;
+      tool_calls?: StreamToolCall[];
+    };
     finish_reason?: string;
   }>;
   usage?: {
@@ -29,7 +39,9 @@ function streamChatCompletion(res: express.Response, completion: {
     total_tokens: number;
   };
 }) {
-  const text = completion.choices?.[0]?.message?.content ?? "";
+  const msg = completion.choices?.[0]?.message;
+  const text = typeof msg?.content === "string" ? msg.content : "";
+  const toolCalls = msg?.tool_calls;
   const finishReason = completion.choices?.[0]?.finish_reason ?? "stop";
 
   res.status(200);
@@ -41,7 +53,24 @@ function streamChatCompletion(res: express.Response, completion: {
     res.write(`data: ${JSON.stringify(payload)}\n\n`);
   };
 
-  // Emit one content delta chunk. This is enough for OpenAI-compatible stream consumers.
+  // Emit one delta chunk containing both content and tool_calls. OpenAI
+  // stream consumers read tool_calls off the delta and accumulate them — a
+  // single chunk with the full shape is accepted by pi-ai and friends.
+  const delta: Record<string, unknown> = {
+    role: "assistant",
+  };
+  if (text.length > 0) {
+    delta.content = text;
+  }
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    delta.tool_calls = toolCalls.map((tc, i) => ({
+      index: i,
+      id: tc.id,
+      type: tc.type,
+      function: tc.function,
+    }));
+  }
+
   writeChunk({
     id: completion.id,
     object: "chat.completion.chunk",
@@ -50,10 +79,7 @@ function streamChatCompletion(res: express.Response, completion: {
     choices: [
       {
         index: 0,
-        delta: {
-          role: "assistant",
-          content: text,
-        },
+        delta,
         finish_reason: null,
       },
     ],

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -3,7 +3,13 @@ import type { Message } from "@anthropic-ai/sdk/resources/messages/messages";
 import pino from "pino";
 
 import { config } from "./config.js";
-import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
+import type {
+  ChatCompletionsRequest,
+  OpenAIToolCall,
+  OpenAIToolChoice,
+  OpenAIToolDef,
+  RouteDecision,
+} from "./types.js";
 
 export const downstreamLogger = pino({
   level: config.nodeEnv === "development" ? "debug" : "info",
@@ -21,7 +27,11 @@ export type DownstreamResponse = {
     index: number;
     message: {
       role: "assistant";
-      content: string;
+      // OpenAI spec: content is null when tool_calls is present. Many
+      // clients accept both null and "" — we emit null when we have tool
+      // calls to match the canonical OpenAI shape.
+      content: string | null;
+      tool_calls?: OpenAIToolCall[];
     };
     finish_reason: string;
   }>;
@@ -194,7 +204,23 @@ type AnthropicImageBlock = {
     | { type: "base64"; media_type: string; data: string }
     | { type: "url"; url: string };
 };
-type AnthropicContentBlock = AnthropicTextBlock | AnthropicImageBlock;
+type AnthropicToolUseBlock = {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+};
+type AnthropicToolResultBlock = {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string | AnthropicTextBlock[];
+  is_error?: boolean;
+};
+type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicImageBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock;
 
 const DATA_URL_RE = /^data:([^;,]+);base64,(.*)$/;
 
@@ -236,6 +262,30 @@ const partToBlock = (part: unknown): AnthropicContentBlock | null => {
   // Native Anthropic image block passthrough.
   if (p.type === "image" && p.source && typeof p.source === "object") {
     return { type: "image", source: p.source as AnthropicImageBlock["source"] };
+  }
+
+  // Native Anthropic tool_use block passthrough (assistant history).
+  if (p.type === "tool_use" && typeof p.id === "string" && typeof p.name === "string") {
+    return { type: "tool_use", id: p.id, name: p.name, input: p.input ?? {} };
+  }
+
+  // Native Anthropic tool_result block passthrough (tool-role history).
+  if (p.type === "tool_result" && typeof p.tool_use_id === "string") {
+    const content =
+      typeof p.content === "string"
+        ? p.content
+        : Array.isArray(p.content)
+          ? p.content
+              .map((c) => partToBlock(c))
+              .filter((b): b is AnthropicTextBlock => b?.type === "text")
+          : stringifyUnknown(p.content);
+    const block: AnthropicToolResultBlock = {
+      type: "tool_result",
+      tool_use_id: p.tool_use_id,
+      content: content as string | AnthropicTextBlock[],
+    };
+    if (p.is_error === true) block.is_error = true;
+    return block;
   }
 
   // Text-like parts.
@@ -328,6 +378,29 @@ export type AnthropicInputMessage = {
   content: AnthropicContentBlock[];
 };
 
+// Convert an OpenAI-style tool_call (as seen on prior assistant turns in
+// ChatMessage.tool_calls) into an Anthropic tool_use block. The OpenAI spec
+// has `arguments` as a JSON-encoded string; we parse it back into an object
+// for Anthropic. Unparseable arguments fall back to {_raw: "..."} so the model
+// still sees what was attempted.
+const openAIToolCallToToolUse = (call: OpenAIToolCall): AnthropicToolUseBlock => {
+  let input: unknown = {};
+  const raw = call.function?.arguments;
+  if (typeof raw === "string" && raw.length > 0) {
+    try {
+      input = JSON.parse(raw);
+    } catch {
+      input = { _raw: raw };
+    }
+  }
+  return {
+    type: "tool_use",
+    id: call.id,
+    name: call.function?.name ?? "unknown",
+    input,
+  };
+};
+
 export const toAnthropicInput = (req: ChatCompletionsRequest): {
   system?: string;
   messages: AnthropicInputMessage[];
@@ -341,17 +414,44 @@ export const toAnthropicInput = (req: ChatCompletionsRequest): {
   const messages: AnthropicInputMessage[] = [];
   for (const m of req.messages) {
     if (m.role === "system") continue;
+
+    // role:"tool" → Anthropic user message with a single tool_result block.
+    // tool_call_id is the link back to the assistant's earlier tool_use.id.
+    if (m.role === "tool") {
+      const toolUseId = m.tool_call_id;
+      if (!toolUseId) {
+        // No correlation id — fall back to a plain text user message so the
+        // content isn't lost.
+        const blocks = normalizeContentToBlocks(m.content);
+        if (blocks.length > 0) messages.push({ role: "user", content: blocks });
+        continue;
+      }
+      const resultContent =
+        typeof m.content === "string"
+          ? m.content
+          : stringifyUnknown(normalizeContentToText(m.content) || m.content);
+      messages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUseId,
+            content: resultContent,
+          },
+        ],
+      });
+      continue;
+    }
+
     const role: "user" | "assistant" = m.role === "assistant" ? "assistant" : "user";
     const blocks = normalizeContentToBlocks(m.content);
 
-    // For tool results, prefix the first text block with a [tool] marker so the
-    // downstream model still sees that the content came from a tool.
-    if (m.role === "tool") {
-      const firstText = blocks.find((b) => b.type === "text") as AnthropicTextBlock | undefined;
-      if (firstText) {
-        firstText.text = `[tool]\n${firstText.text}`;
-      } else {
-        blocks.unshift({ type: "text", text: "[tool]" });
+    // Assistant turns may carry OpenAI-style tool_calls (from prior turns that
+    // the agent replayed). Convert each to an Anthropic tool_use block and
+    // append after the text blocks.
+    if (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+      for (const call of m.tool_calls) {
+        blocks.push(openAIToolCallToToolUse(call));
       }
     }
 
@@ -360,6 +460,56 @@ export const toAnthropicInput = (req: ChatCompletionsRequest): {
   }
 
   return { system: system || undefined, messages };
+};
+
+export const translateToolsToAnthropic = (
+  tools: OpenAIToolDef[] | undefined,
+): Array<{ name: string; description?: string; input_schema: Record<string, unknown> }> | undefined => {
+  if (!Array.isArray(tools) || tools.length === 0) return undefined;
+  const translated = tools
+    .filter(
+      (t): t is OpenAIToolDef =>
+        !!t && t.type === "function" && !!t.function && typeof t.function.name === "string",
+    )
+    .map((t) => {
+      const params = t.function.parameters;
+      const input_schema: Record<string, unknown> =
+        params && typeof params === "object" && !Array.isArray(params)
+          ? (params as Record<string, unknown>)
+          : { type: "object", properties: {} };
+      const out: { name: string; description?: string; input_schema: Record<string, unknown> } = {
+        name: t.function.name,
+        input_schema,
+      };
+      if (typeof t.function.description === "string") {
+        out.description = t.function.description;
+      }
+      return out;
+    });
+  return translated.length > 0 ? translated : undefined;
+};
+
+export const translateToolChoiceToAnthropic = (
+  choice: OpenAIToolChoice | undefined,
+):
+  | { type: "auto" }
+  | { type: "any" }
+  | { type: "none" }
+  | { type: "tool"; name: string }
+  | undefined => {
+  if (!choice) return undefined;
+  if (choice === "auto") return { type: "auto" };
+  if (choice === "none") return { type: "none" };
+  if (choice === "required") return { type: "any" };
+  if (
+    typeof choice === "object" &&
+    choice.type === "function" &&
+    choice.function &&
+    typeof choice.function.name === "string"
+  ) {
+    return { type: "tool", name: choice.function.name };
+  }
+  return undefined;
 };
 
 /**
@@ -394,16 +544,43 @@ export const toOpenAIResponse = (response: Message, model: string): DownstreamRe
     type: "text";
     text: string;
   }>;
+  const toolUseBlocks = response.content.filter((block) => block.type === "tool_use") as Array<{
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+  }>;
+
   const joined = textBlocks.map((block) => block.text).join("\n").trim();
 
-  // When nothing survives the filter, surface a synthetic marker so clients
-  // don't render `(no response)`. This makes regressions loud instead of silent.
-  const content =
-    joined.length > 0
-      ? joined
-      : `[empty response from downstream — stop_reason=${
-          response.stop_reason ?? "unknown"
-        }, blocks=${response.content.map((b) => b.type).join(",") || "none"}]`;
+  const tool_calls: OpenAIToolCall[] | undefined =
+    toolUseBlocks.length > 0
+      ? toolUseBlocks.map((b) => ({
+          id: b.id,
+          type: "function" as const,
+          function: {
+            name: b.name,
+            // OpenAI spec requires a JSON-encoded string for arguments.
+            arguments:
+              typeof b.input === "string" ? b.input : JSON.stringify(b.input ?? {}),
+          },
+        }))
+      : undefined;
+
+  // Content resolution:
+  //   - text present → use joined text
+  //   - no text but tool_calls present → null (canonical OpenAI shape)
+  //   - nothing → synthetic empty-response marker so regressions are loud
+  let content: string | null;
+  if (joined.length > 0) {
+    content = joined;
+  } else if (tool_calls) {
+    content = null;
+  } else {
+    content = `[empty response from downstream — stop_reason=${
+      response.stop_reason ?? "unknown"
+    }, blocks=${response.content.map((b) => b.type).join(",") || "none"}]`;
+  }
 
   const inputTokens = response.usage.input_tokens;
   const outputTokens = response.usage.output_tokens;
@@ -419,6 +596,7 @@ export const toOpenAIResponse = (response: Message, model: string): DownstreamRe
         message: {
           role: "assistant",
           content,
+          ...(tool_calls ? { tool_calls } : {}),
         },
         finish_reason: anthropicStopReasonToOpenAI(response.stop_reason),
       },
@@ -459,6 +637,9 @@ const callAnthropicSdk = async (
     ? systemBlocks.reduce((sum, b) => sum + b.text.length, 0)
     : (systemBlocks?.length ?? 0);
 
+  const anthropicTools = translateToolsToAnthropic(req.tools);
+  const anthropicToolChoice = translateToolChoiceToAnthropic(req.tool_choice);
+
   downstreamLogger.info({
     event: "mux.anthropic_request",
     requestedModel: route.requestedModel,
@@ -469,6 +650,8 @@ const callAnthropicSdk = async (
     rawMessageCount: req.messages.length,
     rawRoles: req.messages.map((m) => m.role),
     messages: summarizeMessagesForLog(messages),
+    toolsCount: anthropicTools?.length ?? 0,
+    toolChoice: anthropicToolChoice ?? null,
   });
 
   try {
@@ -479,15 +662,25 @@ const callAnthropicSdk = async (
       system: systemBlocks as any,
       messages: messages as any,
       stream: false,
+      ...(anthropicTools ? { tools: anthropicTools as any } : {}),
+      ...(anthropicToolChoice ? { tool_choice: anthropicToolChoice as any } : {}),
     });
 
     const textBlocks = response.content.filter((b) => b.type === "text") as Array<{
       type: "text";
       text: string;
     }>;
+    const toolUseBlocks = response.content.filter((b) => b.type === "tool_use") as Array<{
+      type: "tool_use";
+      name: string;
+    }>;
     const joinedTextLength = textBlocks.reduce((sum, b) => sum + b.text.length, 0);
     const blockTypes = response.content.map((b) => b.type);
-    const empty = textBlocks.length === 0 || joinedTextLength === 0;
+    // A response with tool_use blocks is not empty — the model is calling a
+    // tool, even if it produced no user-visible text. Only warn when there is
+    // genuinely nothing for the client to render or act on.
+    const empty =
+      toolUseBlocks.length === 0 && (textBlocks.length === 0 || joinedTextLength === 0);
 
     const respEvent = {
       event: "mux.anthropic_response",
@@ -499,6 +692,8 @@ const callAnthropicSdk = async (
       blockCount: response.content.length,
       blockTypes,
       textBlockCount: textBlocks.length,
+      toolUseBlockCount: toolUseBlocks.length,
+      toolNames: toolUseBlocks.map((b) => b.name),
       joinedTextLength,
       empty,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,41 @@
+export type OpenAIFunctionDef = {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+};
+
+export type OpenAIToolDef = {
+  type: "function";
+  function: OpenAIFunctionDef;
+};
+
+export type OpenAIToolChoice =
+  | "auto"
+  | "none"
+  | "required"
+  | { type: "function"; function: { name: string } };
+
+export type OpenAIToolCall = {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    // OpenAI spec: JSON-encoded string of the arguments.
+    arguments: string;
+  };
+};
+
 export type ChatMessage = {
   role: "system" | "user" | "assistant" | "tool";
   // Upstream clients (OpenAI-style, pi-ai, etc.) send either a plain string
   // or an array of content parts (text, image_url, native Anthropic blocks).
   // We normalize downstream.
   content: unknown;
+  // Present on assistant messages from prior turns that invoked tools.
+  tool_calls?: OpenAIToolCall[];
+  // Present on role:"tool" messages; correlates to the tool_calls[].id that
+  // produced this result.
+  tool_call_id?: string;
 };
 
 export type ChatCompletionsRequest = {
@@ -13,6 +45,8 @@ export type ChatCompletionsRequest = {
   temperature?: number;
   max_tokens?: number;
   runtime?: string;
+  tools?: OpenAIToolDef[];
+  tool_choice?: OpenAIToolChoice;
 };
 
 export type RouteDecision = {

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -9,8 +9,10 @@ import {
   downstreamLogger,
   toAnthropicInput,
   toOpenAIResponse,
+  translateToolChoiceToAnthropic,
+  translateToolsToAnthropic,
 } from "../src/downstream.js";
-import type { ChatCompletionsRequest, RouteDecision } from "../src/types.js";
+import type { ChatCompletionsRequest, OpenAIToolDef, RouteDecision } from "../src/types.js";
 
 const requestPayload: ChatCompletionsRequest = {
   model: "gpt-4o",
@@ -661,5 +663,342 @@ describe("anthropicStopReasonToOpenAI", () => {
     // Unknown values fall back to "stop" instead of throwing, so an
     // unrecognized Anthropic value never poisons downstream agents.
     expect(anthropicStopReasonToOpenAI("totally_made_up" as any)).toBe("stop");
+  });
+});
+
+describe("translateToolsToAnthropic", () => {
+  it("converts OpenAI function tool definitions into Anthropic tool shape", () => {
+    const tools: OpenAIToolDef[] = [
+      {
+        type: "function",
+        function: {
+          name: "gpu_status",
+          description: "Report GPU state",
+          parameters: {
+            type: "object",
+            properties: { verbose: { type: "boolean" } },
+            required: [],
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "read_file",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ];
+    const result = translateToolsToAnthropic(tools);
+    expect(result).toHaveLength(2);
+    expect(result![0]).toEqual({
+      name: "gpu_status",
+      description: "Report GPU state",
+      input_schema: {
+        type: "object",
+        properties: { verbose: { type: "boolean" } },
+        required: [],
+      },
+    });
+    expect(result![1]).toEqual({
+      name: "read_file",
+      input_schema: { type: "object", properties: { path: { type: "string" } } },
+    });
+  });
+
+  it("returns undefined for empty or missing tools", () => {
+    expect(translateToolsToAnthropic(undefined)).toBeUndefined();
+    expect(translateToolsToAnthropic([])).toBeUndefined();
+  });
+
+  it("supplies a default input_schema when parameters are missing", () => {
+    const result = translateToolsToAnthropic([
+      { type: "function", function: { name: "noop" } },
+    ]);
+    expect(result![0]!.input_schema).toEqual({ type: "object", properties: {} });
+  });
+});
+
+describe("translateToolChoiceToAnthropic", () => {
+  it("maps each OpenAI tool_choice variant to the Anthropic shape", () => {
+    expect(translateToolChoiceToAnthropic("auto")).toEqual({ type: "auto" });
+    expect(translateToolChoiceToAnthropic("none")).toEqual({ type: "none" });
+    expect(translateToolChoiceToAnthropic("required")).toEqual({ type: "any" });
+    expect(
+      translateToolChoiceToAnthropic({ type: "function", function: { name: "read_file" } }),
+    ).toEqual({ type: "tool", name: "read_file" });
+    expect(translateToolChoiceToAnthropic(undefined)).toBeUndefined();
+  });
+});
+
+describe("toAnthropicInput — tool round-trip", () => {
+  it("converts an assistant message with OpenAI tool_calls into Anthropic tool_use blocks", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        { role: "user", content: "check gpu" },
+        {
+          role: "assistant",
+          content: "Let me check.",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "gpu_status", arguments: '{"verbose":true}' },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(messages).toHaveLength(2);
+    const assistant = messages[1]!;
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content).toHaveLength(2);
+    expect(assistant.content[0]).toEqual({ type: "text", text: "Let me check." });
+    expect(assistant.content[1]).toEqual({
+      type: "tool_use",
+      id: "call_1",
+      name: "gpu_status",
+      input: { verbose: true },
+    });
+  });
+
+  it("handles unparseable tool_call arguments by wrapping them in {_raw}", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_bad",
+              type: "function",
+              function: { name: "noop", arguments: "not-json" },
+            },
+          ],
+        },
+      ],
+    });
+    const toolUse = messages[0]!.content[0] as { type: "tool_use"; input: unknown };
+    expect(toolUse.type).toBe("tool_use");
+    expect(toolUse.input).toEqual({ _raw: "not-json" });
+  });
+
+  it("converts a role:'tool' message into an Anthropic tool_result block", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: "GPU is idle",
+        },
+      ],
+    });
+
+    expect(messages).toHaveLength(1);
+    const userMsg = messages[0]!;
+    expect(userMsg.role).toBe("user");
+    expect(userMsg.content).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "call_1",
+        content: "GPU is idle",
+      },
+    ]);
+  });
+
+  it("falls back to plain user text when a tool message has no tool_call_id", () => {
+    const { messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "tool", content: "orphaned tool output" }],
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[0]!.content).toEqual([{ type: "text", text: "orphaned tool output" }]);
+  });
+});
+
+describe("toOpenAIResponse — tool_calls surfacing", () => {
+  const baseUsage = { input_tokens: 1, output_tokens: 1 };
+
+  it("exposes Anthropic tool_use blocks as OpenAI tool_calls on the message", () => {
+    const response = toOpenAIResponse(
+      {
+        id: "msg_tool",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [
+          { type: "text", text: "Checking now." },
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "gpu_status",
+            input: { verbose: true },
+          },
+        ],
+        stop_reason: "tool_use",
+        stop_sequence: null,
+        usage: baseUsage,
+      } as unknown as Parameters<typeof toOpenAIResponse>[0],
+      "claude-sonnet-4-6",
+    );
+
+    const msg = response.choices[0]!.message;
+    expect(msg.content).toBe("Checking now.");
+    expect(msg.tool_calls).toEqual([
+      {
+        id: "toolu_1",
+        type: "function",
+        function: { name: "gpu_status", arguments: '{"verbose":true}' },
+      },
+    ]);
+    expect(response.choices[0]!.finish_reason).toBe("tool_calls");
+  });
+
+  it("sets content to null when the only output is a tool_use block", () => {
+    const response = toOpenAIResponse(
+      {
+        id: "msg_tool_only",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [
+          { type: "tool_use", id: "toolu_2", name: "read_file", input: { path: "/etc/hosts" } },
+        ],
+        stop_reason: "tool_use",
+        stop_sequence: null,
+        usage: baseUsage,
+      } as unknown as Parameters<typeof toOpenAIResponse>[0],
+      "claude-sonnet-4-6",
+    );
+
+    const msg = response.choices[0]!.message;
+    expect(msg.content).toBeNull();
+    expect(msg.tool_calls).toHaveLength(1);
+    expect(msg.tool_calls![0]!.function.arguments).toBe('{"path":"/etc/hosts"}');
+    // Must NOT fall through to the synthetic empty-response marker — content
+    // is null (canonical OpenAI shape), not a placeholder string.
+    expect(typeof msg.content === "string" && /empty response/.test(msg.content)).toBe(false);
+  });
+});
+
+describe("callDownstream — tools forwarding to Anthropic SDK", () => {
+  it("forwards req.tools and req.tool_choice to the Anthropic API", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_tool",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [
+            { type: "tool_use", id: "toolu_x", name: "gpu_status", input: {} },
+          ],
+          stop_reason: "tool_use",
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const response = await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "check the gpu" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "gpu_status",
+              description: "Report GPU state",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+        tool_choice: "auto",
+      },
+      { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+    expect(body.tools).toEqual([
+      {
+        name: "gpu_status",
+        description: "Report GPU state",
+        input_schema: { type: "object", properties: {} },
+      },
+    ]);
+    expect(body.tool_choice).toEqual({ type: "auto" });
+
+    // Response round-trips the tool_use block as OpenAI tool_calls.
+    const msg = response.choices[0]!.message;
+    expect(msg.tool_calls).toHaveLength(1);
+    expect(msg.tool_calls![0]!.function.name).toBe("gpu_status");
+    expect(response.choices[0]!.finish_reason).toBe("tool_calls");
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+
+  it("omits tools from the Anthropic request body when req.tools is absent", async () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "hi" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await callDownstream(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+
+    config.downstreamMode = previousMode;
+    config.anthropicOauthToken = previousOauthToken;
+    config.anthropicApiKey = previousApiKey;
+    config.anthropicBaseUrl = previousAnthropicBaseUrl;
   });
 });


### PR DESCRIPTION
## Summary
- Accept OpenAI `tools` and `tool_choice` on `ChatCompletionsRequest` and forward them to the Anthropic API (`translateToolsToAnthropic`, `translateToolChoiceToAnthropic`).
- Assistant history carrying OpenAI `tool_calls[]` is converted into Anthropic `tool_use` blocks (JSON-parsing `arguments`, wrapping unparseable values in `{_raw}`). `role:"tool"` + `tool_call_id` becomes a user message with a `tool_result` block — replacing the old `[tool]\n` prefix hack.
- Anthropic `tool_use` blocks on the response are surfaced as OpenAI `message.tool_calls`, with `content` set to `null` (canonical OpenAI shape) when the only output is a tool call. Synthetic empty-response marker now only fires when there is genuinely nothing to render.
- `streamChatCompletion` emits both `content` and `tool_calls` in its synthesized delta chunk so pi-ai-style streaming consumers see tool calls.
- `mux.anthropic_request` logs `toolsCount` + `toolChoice`. `mux.anthropic_response` logs `toolUseBlockCount` + `toolNames` and no longer warns on tool-only responses.

## Why
Resolves #24 and closes out the live regression on top of arniesaha/agent-max#24. Mux was silently dropping `req.tools` on every request to Anthropic. Claude saw zero tools on every turn and could only reply in prose — producing the "Let me check." loop and the "I don't have access to run shell commands in this conversation" apology captured in Telegram this morning. Diagnostic logging earlier today confirmed agent-max is correctly sending 23 function tools (wake_gpu, shutdown_gpu, gpu_status, read_file, write_file, …) on every request; they were simply not being forwarded.

This is the mechanical fix needed before Max can take multi-step actions or invoke sub-agents end-to-end.

## Test plan
- [x] \`npm run check\` clean
- [x] \`npm test\` → 45/45 pass (12 new tests)
- [x] Covers: tool def translation, tool_choice variants, assistant tool_calls round-trip, unparseable arguments, role:"tool" → tool_result, tool_use response surfacing, tool-only content=null, tools forwarded to Anthropic SDK, negative case (no tools → body.tools absent)
- [ ] Deploy to NAS and confirm \`mux.anthropic_request\` logs \`toolsCount: 23\` on agent-max traffic
- [ ] Confirm \`mux.anthropic_response\` shows \`toolUseBlockCount > 0\` on a tool-invoking turn
- [ ] Telegram repro: "Is Claude desktop running on the Mac?" should result in Max actually invoking a tool rather than apologizing

Closes #24
Refs arniesaha/agent-max#24