### PR TITLE
feat(downstream): real SSE streaming from Anthropic (#25)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import {
   callDownstream,
   DownstreamNotConfiguredError,
   DownstreamRequestError,
+  streamDownstream,
   type DownstreamRequestContext,
 } from "./downstream.js";
 import { resolveRoute } from "./policy.js";
@@ -154,6 +155,11 @@ export const createApp = () => {
       const downstreamContext: DownstreamRequestContext = {
         incomingAuthorizationHeader: req.header("authorization") ?? undefined,
       };
+
+      if (routedBody.stream && config.downstreamMode === "anthropic-sdk") {
+        await streamDownstream(routedBody, route, res);
+        return;
+      }
 
       const downstream = await callDownstream(routedBody, route, downstreamContext);
 

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -1,5 +1,9 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { Message } from "@anthropic-ai/sdk/resources/messages/messages";
+import type {
+  Message,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type express from "express";
 import pino from "pino";
 
 import { config } from "./config.js";
@@ -618,10 +622,16 @@ const summarizeMessagesForLog = (messages: AnthropicInputMessage[]) =>
     return { index, role: m.role, textLength, imageCount, blockCount: m.content.length };
   });
 
-const callAnthropicSdk = async (
+type PreparedAnthropicCall = {
+  client: Anthropic;
+  params: Record<string, unknown>;
+};
+
+const prepareAnthropicCall = (
   req: ChatCompletionsRequest,
   route: RouteDecision,
-): Promise<DownstreamResponse> => {
+  streamed: boolean,
+): PreparedAnthropicCall => {
   const client = getAnthropicClient();
   const { system, messages } = toAnthropicInput(req);
   const isOauth = Boolean(config.anthropicOauthToken?.trim());
@@ -652,18 +662,56 @@ const callAnthropicSdk = async (
     messages: summarizeMessagesForLog(messages),
     toolsCount: anthropicTools?.length ?? 0,
     toolChoice: anthropicToolChoice ?? null,
+    streamed,
   });
+
+  const params: Record<string, unknown> = {
+    model: route.resolvedModel,
+    max_tokens: maxTokens,
+    temperature: req.temperature,
+    system: systemBlocks,
+    messages,
+  };
+  if (anthropicTools) params.tools = anthropicTools;
+  if (anthropicToolChoice) params.tool_choice = anthropicToolChoice;
+
+  return { client, params };
+};
+
+const handleAnthropicSdkError = (
+  error: unknown,
+  route: RouteDecision,
+): DownstreamRequestError | Error => {
+  if (error instanceof Anthropic.APIError) {
+    downstreamLogger.error({
+      event: "mux.anthropic_api_error",
+      resolvedModel: route.resolvedModel,
+      status: error.status ?? null,
+      name: error.name,
+      message: error.message,
+      body: error.error ?? null,
+    });
+    return new DownstreamRequestError(error.status ?? 500, error.error ?? error.message);
+  }
+
+  downstreamLogger.error({
+    event: "mux.anthropic_unknown_error",
+    resolvedModel: route.resolvedModel,
+    err: error instanceof Error ? { name: error.name, message: error.message } : String(error),
+  });
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+const callAnthropicSdk = async (
+  req: ChatCompletionsRequest,
+  route: RouteDecision,
+): Promise<DownstreamResponse> => {
+  const { client, params } = prepareAnthropicCall(req, route, false);
 
   try {
     const response = await client.messages.create({
-      model: route.resolvedModel,
-      max_tokens: maxTokens,
-      temperature: req.temperature,
-      system: systemBlocks as any,
-      messages: messages as any,
+      ...(params as any),
       stream: false,
-      ...(anthropicTools ? { tools: anthropicTools as any } : {}),
-      ...(anthropicToolChoice ? { tool_choice: anthropicToolChoice as any } : {}),
     });
 
     const textBlocks = response.content.filter((b) => b.type === "text") as Array<{
@@ -705,24 +753,7 @@ const callAnthropicSdk = async (
 
     return toOpenAIResponse(response, route.resolvedModel);
   } catch (error) {
-    if (error instanceof Anthropic.APIError) {
-      downstreamLogger.error({
-        event: "mux.anthropic_api_error",
-        resolvedModel: route.resolvedModel,
-        status: error.status ?? null,
-        name: error.name,
-        message: error.message,
-        body: error.error ?? null,
-      });
-      throw new DownstreamRequestError(error.status ?? 500, error.error ?? error.message);
-    }
-
-    downstreamLogger.error({
-      event: "mux.anthropic_unknown_error",
-      resolvedModel: route.resolvedModel,
-      err: error instanceof Error ? { name: error.name, message: error.message } : String(error),
-    });
-    throw error;
+    throw handleAnthropicSdkError(error, route);
   }
 };
 
@@ -746,4 +777,262 @@ export const callDownstream = async (
   }
 
   return callOpenAICompatible(req, route, context);
+};
+
+// --- Streaming path ------------------------------------------------------
+
+export type StreamLogCtx = {
+  requestedModel: string;
+  resolvedModel: string;
+};
+
+type ToolCallAccum = {
+  index: number;
+  id: string;
+  name: string;
+  argsLength: number;
+};
+
+// Consume an async-iterable of Anthropic RawMessageStreamEvents and write
+// OpenAI-shaped chat.completion.chunk SSE frames to `res`. Returns once the
+// stream is fully drained (or a terminal error chunk has been written). The
+// caller is responsible for setting SSE headers BEFORE invoking this.
+export const streamAnthropicToOpenAI = async (
+  events: AsyncIterable<RawMessageStreamEvent>,
+  res: express.Response,
+  model: string,
+  logCtx: StreamLogCtx,
+  onAbort?: () => void,
+): Promise<void> => {
+  const streamId = `chatcmpl-${Date.now()}`;
+  const created = Math.floor(Date.now() / 1000);
+
+  const writeChunk = (delta: Record<string, unknown>, finishReason: string | null) => {
+    const payload = {
+      id: streamId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta,
+          finish_reason: finishReason,
+        },
+      ],
+    };
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    const anyRes = res as unknown as { flush?: () => void };
+    if (typeof anyRes.flush === "function") anyRes.flush();
+  };
+
+  // block_index (Anthropic) → accumulator. We map each Anthropic content-block
+  // index to a dense OpenAI tool_calls index so clients see 0,1,2... even if
+  // Anthropic emits blocks at e.g. index 1 (text at 0, tool_use at 1).
+  const toolCalls = new Map<number, ToolCallAccum>();
+  let nextToolIndex = 0;
+  let textLength = 0;
+  let finalStopReason: string | null = null;
+  let phase: string = "start";
+  let aborted = false;
+  let clientClosed = false;
+
+  const onClose = () => {
+    clientClosed = true;
+    if (!aborted) {
+      aborted = true;
+      try {
+        onAbort?.();
+      } catch {
+        // swallow — best-effort abort
+      }
+      downstreamLogger.info({
+        event: "mux.anthropic_stream_client_closed",
+        resolvedModel: logCtx.resolvedModel,
+        phase,
+      });
+    }
+  };
+  res.once("close", onClose);
+
+  writeChunk({ role: "assistant" }, null);
+
+  try {
+    for await (const event of events) {
+      if (clientClosed) break;
+      phase = event.type;
+      switch (event.type) {
+        case "message_start":
+          // role chunk already emitted; nothing else to do
+          break;
+        case "content_block_start": {
+          const block = (event as { content_block: { type: string; id?: string; name?: string } }).content_block;
+          if (block.type === "tool_use") {
+            const idx = nextToolIndex++;
+            toolCalls.set(event.index, {
+              index: idx,
+              id: block.id ?? "",
+              name: block.name ?? "",
+              argsLength: 0,
+            });
+            writeChunk(
+              {
+                tool_calls: [
+                  {
+                    index: idx,
+                    id: block.id ?? "",
+                    type: "function",
+                    function: { name: block.name ?? "", arguments: "" },
+                  },
+                ],
+              },
+              null,
+            );
+          }
+          break;
+        }
+        case "content_block_delta": {
+          const delta = (event as { delta: { type: string; text?: string; partial_json?: string } }).delta;
+          if (delta.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
+            textLength += delta.text.length;
+            writeChunk({ content: delta.text }, null);
+          } else if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+            const accum = toolCalls.get(event.index);
+            if (accum) {
+              accum.argsLength += delta.partial_json.length;
+              writeChunk(
+                {
+                  tool_calls: [
+                    {
+                      index: accum.index,
+                      function: { arguments: delta.partial_json },
+                    },
+                  ],
+                },
+                null,
+              );
+            }
+          }
+          break;
+        }
+        case "content_block_stop":
+          // accumulator closes implicitly
+          break;
+        case "message_delta": {
+          const d = (event as { delta: { stop_reason?: string | null } }).delta;
+          if (d && typeof d.stop_reason === "string") {
+            finalStopReason = d.stop_reason;
+          }
+          break;
+        }
+        case "message_stop":
+          // terminal — fall through to end-of-stream logic below
+          break;
+        default:
+          break;
+      }
+    }
+
+    const toolUseBlockCount = toolCalls.size;
+    const empty = toolUseBlockCount === 0 && textLength === 0;
+    const respEvent = {
+      event: "mux.anthropic_response",
+      resolvedModel: logCtx.resolvedModel,
+      stopReason: finalStopReason,
+      stopSequence: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      blockCount: (textLength > 0 ? 1 : 0) + toolUseBlockCount,
+      blockTypes: [
+        ...(textLength > 0 ? ["text"] : []),
+        ...Array.from({ length: toolUseBlockCount }, () => "tool_use"),
+      ],
+      textBlockCount: textLength > 0 ? 1 : 0,
+      toolUseBlockCount,
+      toolNames: Array.from(toolCalls.values()).map((t) => t.name),
+      joinedTextLength: textLength,
+      empty,
+      streamed: true,
+    };
+    if (empty) {
+      downstreamLogger.warn(respEvent);
+    } else {
+      downstreamLogger.info(respEvent);
+    }
+
+    if (!clientClosed) {
+      writeChunk({}, anthropicStopReasonToOpenAI(finalStopReason));
+      res.write("data: [DONE]\n\n");
+      res.end();
+    }
+  } catch (err) {
+    downstreamLogger.error({
+      event: "mux.anthropic_stream_error",
+      resolvedModel: logCtx.resolvedModel,
+      phase,
+      err: err instanceof Error ? { name: err.name, message: err.message } : String(err),
+    });
+    if (!clientClosed) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writeChunk({ content: `[stream error: ${msg}]` }, null);
+      writeChunk({}, anthropicStopReasonToOpenAI(finalStopReason));
+      res.write("data: [DONE]\n\n");
+      res.end();
+    }
+  } finally {
+    res.off("close", onClose);
+  }
+};
+
+export const streamDownstream = async (
+  req: ChatCompletionsRequest,
+  route: RouteDecision,
+  res: express.Response,
+): Promise<void> => {
+  if (config.downstreamMode !== "anthropic-sdk") {
+    throw new Error("streamDownstream is only supported in anthropic-sdk mode");
+  }
+
+  const { client, params } = prepareAnthropicCall(req, route, true);
+
+  // Stream-start errors (auth, 4xx) surface here BEFORE any bytes hit the
+  // wire. Convert to DownstreamRequestError so app.ts's existing 502 branch
+  // sends a JSON error response.
+  let stream: Awaited<ReturnType<typeof client.messages.create>>;
+  try {
+    stream = (await client.messages.create({
+      ...(params as any),
+      stream: true,
+    })) as any;
+  } catch (error) {
+    throw handleAnthropicSdkError(error, route);
+  }
+
+  // Once the stream object exists, the SDK has received HTTP headers — from
+  // here on, we own the response body and MUST NOT throw past app.ts.
+  if (!res.headersSent) {
+    res.status(200);
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+  }
+
+  const abortable = stream as unknown as {
+    controller?: AbortController;
+    [Symbol.asyncIterator]: () => AsyncIterator<RawMessageStreamEvent>;
+  };
+
+  await streamAnthropicToOpenAI(
+    abortable as AsyncIterable<RawMessageStreamEvent>,
+    res,
+    route.resolvedModel,
+    { requestedModel: route.requestedModel, resolvedModel: route.resolvedModel },
+    () => {
+      try {
+        abortable.controller?.abort();
+      } catch {
+        // best effort
+      }
+    },
+  );
 };

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -5,8 +5,11 @@ import {
   __resetAnthropicClientForTests,
   callDownstream,
   DownstreamNotConfiguredError,
+  DownstreamRequestError,
   anthropicStopReasonToOpenAI,
   downstreamLogger,
+  streamAnthropicToOpenAI,
+  streamDownstream,
   toAnthropicInput,
   toOpenAIResponse,
   translateToolChoiceToAnthropic,
@@ -1000,5 +1003,430 @@ describe("callDownstream — tools forwarding to Anthropic SDK", () => {
     config.anthropicOauthToken = previousOauthToken;
     config.anthropicApiKey = previousApiKey;
     config.anthropicBaseUrl = previousAnthropicBaseUrl;
+  });
+});
+
+// --- streaming helper + integration -----------------------------------------
+
+type StubResponse = {
+  writes: string[];
+  statusCode: number | null;
+  headers: Record<string, string>;
+  ended: boolean;
+  status: (code: number) => StubResponse;
+  setHeader: (k: string, v: string) => void;
+  getHeader: (k: string) => string | undefined;
+  headersSent: boolean;
+  write: (chunk: string) => boolean;
+  end: () => void;
+  once: (event: string, cb: () => void) => void;
+  off: (event: string, cb: () => void) => void;
+  emit: (event: string) => void;
+  _listeners: Record<string, Array<() => void>>;
+};
+
+const makeStubRes = (): StubResponse => {
+  const res: StubResponse = {
+    writes: [],
+    statusCode: null,
+    headers: {},
+    ended: false,
+    headersSent: false,
+    _listeners: {},
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      res.headers[k] = v;
+    },
+    getHeader(k: string) {
+      return res.headers[k];
+    },
+    write(chunk: string) {
+      res.headersSent = true;
+      res.writes.push(chunk);
+      return true;
+    },
+    end() {
+      res.ended = true;
+    },
+    once(event: string, cb: () => void) {
+      (res._listeners[event] ||= []).push(cb);
+    },
+    off(event: string, cb: () => void) {
+      const list = res._listeners[event];
+      if (!list) return;
+      const i = list.indexOf(cb);
+      if (i >= 0) list.splice(i, 1);
+    },
+    emit(event: string) {
+      for (const cb of res._listeners[event] ?? []) cb();
+    },
+  };
+  return res;
+};
+
+const parseSseFrames = (writes: string[]): Array<Record<string, unknown> | "[DONE]"> => {
+  const frames: Array<Record<string, unknown> | "[DONE]"> = [];
+  const joined = writes.join("");
+  for (const raw of joined.split("\n\n")) {
+    const line = raw.trim();
+    if (!line.startsWith("data: ")) continue;
+    const body = line.slice(6);
+    if (body === "[DONE]") {
+      frames.push("[DONE]");
+      continue;
+    }
+    frames.push(JSON.parse(body));
+  }
+  return frames;
+};
+
+const eventsAsAsyncIterable = <T>(events: T[]): AsyncIterable<T> => ({
+  [Symbol.asyncIterator]() {
+    let i = 0;
+    return {
+      async next() {
+        if (i >= events.length) return { value: undefined as unknown as T, done: true };
+        return { value: events[i++]!, done: false };
+      },
+    };
+  },
+});
+
+describe("streamAnthropicToOpenAI", () => {
+  it("emits role chunk, text deltas, final finish_reason, and [DONE]", async () => {
+    const res = makeStubRes();
+    const events = [
+      { type: "message_start", message: { id: "msg_1" } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hel" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "lo" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null } },
+      { type: "message_stop" },
+    ];
+
+    await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const frames = parseSseFrames(res.writes);
+    expect(frames[frames.length - 1]).toBe("[DONE]");
+    const chunks = frames.filter((f): f is Record<string, unknown> => f !== "[DONE]");
+    // 1: role, 2: "hel", 3: "lo", 4: final finish_reason
+    expect(chunks).toHaveLength(4);
+
+    const firstDelta = (chunks[0] as any).choices[0].delta;
+    expect(firstDelta).toEqual({ role: "assistant" });
+    expect((chunks[0] as any).choices[0].finish_reason).toBeNull();
+
+    expect((chunks[1] as any).choices[0].delta).toEqual({ content: "hel" });
+    expect((chunks[2] as any).choices[0].delta).toEqual({ content: "lo" });
+
+    const last = chunks[3] as any;
+    expect(last.choices[0].delta).toEqual({});
+    expect(last.choices[0].finish_reason).toBe("stop");
+    expect(res.ended).toBe(true);
+  });
+
+  it("streams tool_use start + input_json_delta fragments with the same index", async () => {
+    const res = makeStubRes();
+    const events = [
+      { type: "message_start", message: { id: "msg_1" } },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "toolu_1", name: "read_file", input: {} },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"path":"/e' },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: 'tc/hosts"}' },
+      },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null } },
+      { type: "message_stop" },
+    ];
+
+    await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const chunks = parseSseFrames(res.writes).filter(
+      (f): f is Record<string, unknown> => f !== "[DONE]",
+    );
+    // Role chunk + tool_use start + 2 argument fragments + final.
+    expect(chunks).toHaveLength(5);
+
+    const toolStart = (chunks[1] as any).choices[0].delta.tool_calls;
+    expect(toolStart).toEqual([
+      {
+        index: 0,
+        id: "toolu_1",
+        type: "function",
+        function: { name: "read_file", arguments: "" },
+      },
+    ]);
+
+    // Subsequent deltas carry PARTIAL fragments at the same tool_calls index.
+    // The client concatenates; we must not do it ourselves.
+    const frag1 = (chunks[2] as any).choices[0].delta.tool_calls;
+    expect(frag1).toEqual([{ index: 0, function: { arguments: '{"path":"/e' } }]);
+    const frag2 = (chunks[3] as any).choices[0].delta.tool_calls;
+    expect(frag2).toEqual([{ index: 0, function: { arguments: 'tc/hosts"}' } }]);
+
+    // Final chunk uses tool_use → tool_calls mapping.
+    expect((chunks[4] as any).choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("writes a terminal [stream error:] chunk when the event source throws", async () => {
+    const res = makeStubRes();
+    const events: AsyncIterable<any> = {
+      [Symbol.asyncIterator]() {
+        let sent = 0;
+        return {
+          async next() {
+            if (sent === 0) {
+              sent++;
+              return { value: { type: "message_start", message: { id: "x" } }, done: false };
+            }
+            throw new Error("transport died");
+          },
+        };
+      },
+    };
+
+    await streamAnthropicToOpenAI(
+      events,
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const joined = res.writes.join("");
+    expect(joined).toContain("[stream error: transport died]");
+    expect(joined.endsWith("data: [DONE]\n\n")).toBe(true);
+    expect(res.ended).toBe(true);
+  });
+});
+
+describe("streamDownstream", () => {
+  const setupAnthropic = () => {
+    const previousMode = config.downstreamMode;
+    const previousOauthToken = config.anthropicOauthToken;
+    const previousApiKey = config.anthropicApiKey;
+    const previousAnthropicBaseUrl = config.anthropicBaseUrl;
+
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://127.0.0.1:30400";
+
+    return () => {
+      config.downstreamMode = previousMode;
+      config.anthropicOauthToken = previousOauthToken;
+      config.anthropicApiKey = previousApiKey;
+      config.anthropicBaseUrl = previousAnthropicBaseUrl;
+    };
+  };
+
+  const sseResponse = (frames: string[]): Response => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const f of frames) controller.enqueue(encoder.encode(f));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  };
+
+  const anthropicSseFrame = (eventName: string, data: unknown): string =>
+    `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+
+  it("produces OpenAI chunks and a terminal [DONE] for a text stream", async () => {
+    const restore = setupAnthropic();
+    try {
+      const frames = [
+        anthropicSseFrame("message_start", {
+          type: "message_start",
+          message: {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            model: "claude-sonnet-4-6",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 0 },
+          },
+        }),
+        anthropicSseFrame("content_block_start", {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        }),
+        anthropicSseFrame("content_block_delta", {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "hi" },
+        }),
+        anthropicSseFrame("content_block_delta", {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: " there" },
+        }),
+        anthropicSseFrame("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSseFrame("message_delta", {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn", stop_sequence: null },
+          usage: { output_tokens: 5 },
+        }),
+        anthropicSseFrame("message_stop", { type: "message_stop" }),
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(sseResponse(frames));
+
+      const res = makeStubRes();
+      await streamDownstream(
+        {
+          model: "claude-sonnet-4-6",
+          messages: [{ role: "user", content: "hi" }],
+          stream: true,
+        },
+        { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+        res as unknown as import("express").Response,
+      );
+
+      expect(res.headers["Content-Type"]).toContain("text/event-stream");
+      const parsed = parseSseFrames(res.writes);
+      expect(parsed[parsed.length - 1]).toBe("[DONE]");
+      const chunks = parsed.filter((f): f is Record<string, unknown> => f !== "[DONE]");
+      const content = chunks
+        .map((c: any) => c.choices?.[0]?.delta?.content)
+        .filter(Boolean)
+        .join("");
+      expect(content).toBe("hi there");
+      const final = chunks[chunks.length - 1] as any;
+      // Anthropic end_turn → OpenAI stop (via anthropicStopReasonToOpenAI).
+      expect(final.choices[0].finish_reason).toBe("stop");
+    } finally {
+      restore();
+    }
+  });
+
+  it("rejects with DownstreamRequestError when the stream start fails", async () => {
+    const restore = setupAnthropic();
+    try {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            type: "error",
+            error: { type: "invalid_request_error", message: "bad prompt" },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+      const res = makeStubRes();
+      await expect(
+        streamDownstream(
+          {
+            model: "claude-sonnet-4-6",
+            messages: [{ role: "user", content: "hi" }],
+            stream: true,
+          },
+          { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+          res as unknown as import("express").Response,
+        ),
+      ).rejects.toBeInstanceOf(DownstreamRequestError);
+
+      // No bytes may be written when the start fails — app.ts's 502 branch
+      // takes over and sends a JSON error.
+      expect(res.writes).toHaveLength(0);
+      expect(res.ended).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("fires mux.anthropic_request with streamed:true and mux.anthropic_response on success", async () => {
+    const restore = setupAnthropic();
+    try {
+      const frames = [
+        anthropicSseFrame("message_start", {
+          type: "message_start",
+          message: {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            model: "claude-sonnet-4-6",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 0 },
+          },
+        }),
+        anthropicSseFrame("content_block_start", {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        }),
+        anthropicSseFrame("content_block_delta", {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "ok" },
+        }),
+        anthropicSseFrame("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSseFrame("message_delta", {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn", stop_sequence: null },
+          usage: { output_tokens: 1 },
+        }),
+        anthropicSseFrame("message_stop", { type: "message_stop" }),
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(sseResponse(frames));
+
+      const infoSpy = vi.spyOn(downstreamLogger, "info");
+
+      const res = makeStubRes();
+      await streamDownstream(
+        {
+          model: "claude-sonnet-4-6",
+          messages: [{ role: "user", content: "hi" }],
+          stream: true,
+        },
+        { ...route, requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+        res as unknown as import("express").Response,
+      );
+
+      const calls = infoSpy.mock.calls.map((c) => c[0] as Record<string, unknown>);
+      const reqEvent = calls.find((c) => c.event === "mux.anthropic_request");
+      expect(reqEvent).toBeDefined();
+      expect(reqEvent?.streamed).toBe(true);
+
+      const respEvent = calls.find((c) => c.event === "mux.anthropic_response");
+      expect(respEvent).toBeDefined();
+      expect(respEvent?.streamed).toBe(true);
+      expect(respEvent?.stopReason).toBe("end_turn");
+      expect(respEvent?.joinedTextLength).toBe(2);
+    } finally {
+      restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Replace the synthesized stream path for `anthropic-sdk` mode with a real Anthropic SSE stream, mapping `RawMessageStreamEvent`s to OpenAI `chat.completion.chunk` frames.
- New `streamAnthropicToOpenAI()` helper + `streamDownstream()` dispatcher in `src/downstream.ts`; `src/app.ts` routes `stream=true` through the new path when `downstreamMode === "anthropic-sdk"`. The `openai-compatible` path still uses `streamChatCompletion`.
- Streaming `tool_use` is emitted as an initial `tool_calls` delta (id + name + empty args) followed by subsequent deltas that carry each `input_json_delta.partial_json` as an `arguments` fragment at the same index — matching how pi-ai and OpenAI clients concatenate tool call arguments.
- Stop reasons flow through the existing `anthropicStopReasonToOpenAI` helper from #27: `end_turn -> stop`, `tool_use -> tool_calls`, `max_tokens -> length`.
- Stream-start errors (auth / 4xx) still surface as `DownstreamRequestError` so app.ts's 502 JSON branch takes over. Mid-stream errors log `mux.anthropic_stream_error` and write a terminal `[stream error: ...]` content chunk + `[DONE]`. Client disconnect aborts the SDK stream via its `AbortController`.
- `mux.anthropic_request` and `mux.anthropic_response` now carry `streamed: true` on the streaming path; empty-detection logic preserved.

Builds on #28 (tools forwarding) — the streaming path emits incremental tool_calls deltas layered on top of the existing round-trip.

## Test plan
- [x] `npm run check` (tsc --noEmit) clean
- [x] `npm test` — 45 baseline -> 51 passing
- [x] Unit: `streamAnthropicToOpenAI` emits role chunk, text deltas in order, final `finish_reason`, and `[DONE]`
- [x] Unit: `tool_use` start + two `input_json_delta` fragments produce two tool_calls deltas at the same `index`, arguments kept as separate fragments (not concatenated server-side)
- [x] Unit: mid-stream throw writes `[stream error: ...]` + `[DONE]` and closes the response
- [x] Integration: `streamDownstream` consumes a `ReadableStream` of Anthropic SSE frames via `vi.spyOn(globalThis, "fetch")`, produces OpenAI chunks whose joined content matches, final `finish_reason === "stop"` for `end_turn`
- [x] Integration: `streamDownstream` rejects with `DownstreamRequestError` on a 4xx start and writes zero bytes to `res`
- [x] Integration: `mux.anthropic_request` / `mux.anthropic_response` fire with `streamed: true`