### PR TITLE
fix(downstream): emit real Anthropic token counts on streamed responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,5 +43,5 @@ ANTHROPIC_OAUTH_TOKEN=
 # API key fallback (optional):
 ANTHROPIC_API_KEY=
 # Optional; if empty uses Anthropic default API endpoint.
-# For AgentWeave proxy: http://192.168.1.70:30400
+# For AgentWeave proxy: http://arnabsnas.local:30400
 ANTHROPIC_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Mux uses the official `@anthropic-ai/sdk` directly.
 ```bash
 DOWNSTREAM_MODE=anthropic-sdk
 ANTHROPIC_OAUTH_TOKEN=sk-ant-oat01-...
-ANTHROPIC_BASE_URL=http://192.168.1.70:30400
+ANTHROPIC_BASE_URL=http://arnabsnas.local:30400
 DOWNSTREAM_TIMEOUT_MS=30000
 ```
 
@@ -155,6 +155,10 @@ Notes:
 - Keep sending OpenAI-compatible requests to Mux (`/v1/chat/completions`); Mux translates to Anthropic Messages API internally.
 - `ANTHROPIC_API_KEY` can be used instead of `ANTHROPIC_OAUTH_TOKEN` for non-OAuth setups.
 - In `anthropic-sdk` mode, LiteLLM/OpenAI downstream auth settings are ignored.
+
+### Local DNS / hosting
+
+Mux is hosted on a NAS that advertises itself as `arnabsnas.local` via avahi/mDNS. LAN clients should prefer `arnabsnas.local:<PORT>` over raw IPs so setups survive DHCP lease changes without needing router DNS entries. Co-resident services on the NAS can still hit `localhost:<PORT>` for loopback performance.
 
 ### Test
 
@@ -197,7 +201,7 @@ curl -s http://localhost:8787/v1/chat/completions \
     - and `DOWNSTREAM_MOCK_FALLBACK=false`, Mux returns `503 service_unavailable`
 - `DOWNSTREAM_MODE=anthropic-sdk`:
   - Mux calls Anthropic via Node SDK (`@anthropic-ai/sdk`) using `ANTHROPIC_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`).
-  - Optional `ANTHROPIC_BASE_URL` supports proxy endpoints like `http://192.168.1.70:30400`.
+  - Optional `ANTHROPIC_BASE_URL` supports proxy endpoints like `http://arnabsnas.local:30400`.
   - Current limitations: no streaming support yet and chat role mapping is text-only (system/user/assistant; `tool` is flattened to text).
 
 ### Environment variables

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -833,6 +833,8 @@ export const streamAnthropicToOpenAI = async (
   let nextToolIndex = 0;
   let textLength = 0;
   let finalStopReason: string | null = null;
+  let inputTokens = 0;
+  let outputTokens = 0;
   let phase: string = "start";
   let aborted = false;
   let clientClosed = false;
@@ -862,9 +864,14 @@ export const streamAnthropicToOpenAI = async (
       if (clientClosed) break;
       phase = event.type;
       switch (event.type) {
-        case "message_start":
-          // role chunk already emitted; nothing else to do
+        case "message_start": {
+          // role chunk already emitted; capture input token count from usage
+          const msg = (event as { message?: { usage?: { input_tokens?: number } } }).message;
+          if (msg?.usage && typeof msg.usage.input_tokens === "number") {
+            inputTokens = msg.usage.input_tokens;
+          }
           break;
+        }
         case "content_block_start": {
           const block = (event as { content_block: { type: string; id?: string; name?: string } }).content_block;
           if (block.type === "tool_use") {
@@ -919,9 +926,14 @@ export const streamAnthropicToOpenAI = async (
           // accumulator closes implicitly
           break;
         case "message_delta": {
-          const d = (event as { delta: { stop_reason?: string | null } }).delta;
+          const d = (event as { delta: { stop_reason?: string | null }; usage?: { output_tokens?: number } }).delta;
           if (d && typeof d.stop_reason === "string") {
             finalStopReason = d.stop_reason;
+          }
+          // Anthropic output_tokens is cumulative — always take the latest value
+          const mdUsage = (event as { usage?: { output_tokens?: number } }).usage;
+          if (mdUsage && typeof mdUsage.output_tokens === "number") {
+            outputTokens = mdUsage.output_tokens;
           }
           break;
         }
@@ -940,8 +952,8 @@ export const streamAnthropicToOpenAI = async (
       resolvedModel: logCtx.resolvedModel,
       stopReason: finalStopReason,
       stopSequence: null,
-      inputTokens: 0,
-      outputTokens: 0,
+      inputTokens,
+      outputTokens,
       blockCount: (textLength > 0 ? 1 : 0) + toolUseBlockCount,
       blockTypes: [
         ...(textLength > 0 ? ["text"] : []),

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -1221,6 +1221,85 @@ describe("streamAnthropicToOpenAI", () => {
     expect(joined.endsWith("data: [DONE]\n\n")).toBe(true);
     expect(res.ended).toBe(true);
   });
+
+  it("logs real input/output token counts from message_start and message_delta", async () => {
+    const res = makeStubRes();
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_1",
+          usage: { input_tokens: 42, output_tokens: 0 },
+        },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 17 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const infoSpy = vi.spyOn(downstreamLogger, "info");
+
+    await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const calls = infoSpy.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const respEvent = calls.find((c) => c.event === "mux.anthropic_response");
+    expect(respEvent).toBeDefined();
+    expect(respEvent?.inputTokens).toBe(42);
+    expect(respEvent?.outputTokens).toBe(17);
+  });
+
+  it("uses the final cumulative output_tokens when message_delta fires multiple times", async () => {
+    const res = makeStubRes();
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_1",
+          usage: { input_tokens: 10, output_tokens: 0 },
+        },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "a" } },
+      { type: "content_block_stop", index: 0 },
+      // Anthropic emits output_tokens cumulatively — successive message_delta
+      // events should overwrite, not sum. Final value should win.
+      { type: "message_delta", delta: { stop_reason: null }, usage: { output_tokens: 3 } },
+      { type: "message_delta", delta: { stop_reason: null }, usage: { output_tokens: 7 } },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 25 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const infoSpy = vi.spyOn(downstreamLogger, "info");
+
+    await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const calls = infoSpy.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const respEvent = calls.find((c) => c.event === "mux.anthropic_response");
+    expect(respEvent).toBeDefined();
+    expect(respEvent?.inputTokens).toBe(10);
+    // Must be the last seen value (25), NOT a sum (3 + 7 + 25 = 35).
+    expect(respEvent?.outputTokens).toBe(25);
+  });
 });
 
 describe("streamDownstream", () => {


### PR DESCRIPTION
## Summary
- Fixes #30. The Anthropic streaming path in streamAnthropicToOpenAI was hardcoding inputTokens: 0, outputTokens: 0 in the mux.anthropic_response log event, breaking cost observability for streamed requests.
- Extracts input_tokens from the message_start event and tracks cumulative output_tokens from message_delta events, using the final value seen.
- Field names (inputTokens, outputTokens) match the existing non-streaming path for log consumer symmetry.

## How it works
Anthropic streams expose token counts across two event types:
- message_start: carries message.usage.input_tokens (prompt token count)
- message_delta: carries usage.output_tokens (cumulative output tokens)

The fix initializes two accumulators, captures input tokens once from message_start, overwrites outputTokens on each message_delta (cumulative semantics, not additive), and passes both into the existing log event.

## Test plan
- Added test: logs real input/output token counts from message_start and message_delta
- Added test: uses the final cumulative output_tokens when message_delta fires multiple times
- All 53 tests pass, 0 regressions