### PR TITLE
feat(tracing): cost + caller agent id spans; README + gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules/
 dist/
 .env
+.env.*
+!.env.example
+.venv-litellm/
+.litellm.e2e.yaml
+.litellm.e2e.yaml.*
+run/
+linkedin-draft.md

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Mux routes requests using configurable policy rules:
 
 | Request type | Resolved model |
 |---|---|
-| Lightweight / general chat | `claude-sonnet-4-6` |
-| Coding / debugging | `claude-sonnet-4-6` |
-| Complex reasoning / planning | `claude-opus-4-6` |
+| Short lightweight prompts (< 80 chars, no task cues) | `claude-haiku-4-5-20251001` |
+| Coding / debugging / execution cues | `claude-sonnet-4-6` |
+| Complex reasoning / planning / architecture cues | `claude-opus-4-6` |
 | `gpt-4o` (simple prompts) | downgraded to `gpt-4o-mini` |
+
+Routing for Max runtime requests is evaluated on the **last user message only** — system prompts and conversation history are ignored to prevent false escalation.
 
 Route decisions are logged with: `runtime`, `requestedModel`, `resolvedModel`, `routeReason`, `provider`, `backendTarget`.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,7 @@ export const createApp = () => {
       const runtime = body.runtime || req.header("x-runtime") || "unknown";
       const routedBody: ChatCompletionsRequest = { ...body, runtime };
       const route = resolveRoute(routedBody);
+      const callerAgentId = req.header("x-agentweave-agent-id");
 
       // Extract a short prompt preview from the last user message for tracing
       const lastUserMsg = [...body.messages].reverse().find(m => m.role === "user");
@@ -60,8 +61,10 @@ export const createApp = () => {
         "prov.route.reason": route.routeReason,
         "prov.route.runtime": runtime,
         "prov.route.provider_id": route.providerId,
+        "prov.llm.model": route.resolvedModel,
         "prov.llm.prompt_preview": promptPreview,
         "prov.route.message_count": body.messages.length,
+        ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
       });
 
       logger.info({

--- a/src/providers/anthropic-sdk.ts
+++ b/src/providers/anthropic-sdk.ts
@@ -5,6 +5,7 @@ import type {
 import type express from "express";
 
 import { setSpanAttrs, withLlmSpan } from "../tracing.js";
+import { computeCostUsd, resolveCallerAgentId } from "./cost.js";
 import type { ChatCompletionsRequest, RouteDecision } from "../types.js";
 import {
   anthropicStopReasonToOpenAI,
@@ -195,11 +196,20 @@ export const createAnthropicSdkProvider = (cfg: ProviderConfig): Provider => {
         const blockTypes = response.content.map((b) => b.type);
         const empty = toolUseBlocks.length === 0 && (textBlocks.length === 0 || joinedTextLength === 0);
 
+        const costUsd = computeCostUsd(
+          cfg,
+          route.resolvedModel,
+          response.usage.input_tokens,
+          response.usage.output_tokens,
+        );
+        const callerAgentId = resolveCallerAgentId(context);
         setSpanAttrs({
           "prov.llm.prompt_tokens": response.usage.input_tokens,
           "prov.llm.completion_tokens": response.usage.output_tokens,
           "prov.llm.total_tokens": response.usage.input_tokens + response.usage.output_tokens,
           "prov.llm.stop_reason": anthropicStopReasonToOpenAI(response.stop_reason) ?? "unknown",
+          "cost.usd": costUsd,
+          ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
         });
 
         const respEvent = {
@@ -267,11 +277,20 @@ export const createAnthropicSdkProvider = (cfg: ProviderConfig): Provider => {
         },
       );
 
+      const costUsd = computeCostUsd(
+        cfg,
+        route.resolvedModel,
+        result.inputTokens,
+        result.outputTokens,
+      );
+      const callerAgentId = resolveCallerAgentId(context);
       setSpanAttrs({
         "prov.llm.prompt_tokens": result.inputTokens,
         "prov.llm.completion_tokens": result.outputTokens,
         "prov.llm.total_tokens": result.inputTokens + result.outputTokens,
         "prov.llm.stop_reason": anthropicStopReasonToOpenAI(result.stopReason) ?? "unknown",
+        "cost.usd": costUsd,
+        ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
       });
     });
   };

--- a/src/providers/cost.ts
+++ b/src/providers/cost.ts
@@ -1,0 +1,23 @@
+import type { ProviderConfig } from "./types.js";
+
+export const computeCostUsd = (
+  cfg: ProviderConfig,
+  resolvedModel: string,
+  promptTokens: number,
+  completionTokens: number,
+): number => {
+  const model = cfg.models.find((m) => m.id === resolvedModel);
+  if (!model) return 0;
+  const inPrice = model.costInputUsdPerMTok ?? 0;
+  const outPrice = model.costOutputUsdPerMTok ?? 0;
+  return (
+    (promptTokens / 1_000_000) * inPrice +
+    (completionTokens / 1_000_000) * outPrice
+  );
+};
+
+export const resolveCallerAgentId = (context?: {
+  agentweaveHeaders?: Record<string, string>;
+}): string | undefined => {
+  return context?.agentweaveHeaders?.["x-agentweave-agent-id"];
+};

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -1,6 +1,7 @@
 import type express from "express";
 
 import { setSpanAttrs, withLlmSpan } from "../tracing.js";
+import { computeCostUsd, resolveCallerAgentId } from "./cost.js";
 import type { ChatCompletionsRequest, RouteDecision } from "../types.js";
 import {
   buildMockResponse,
@@ -120,11 +121,17 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
         const result = (await response.json()) as DownstreamResponse;
         const latencyMs = Date.now() - startedAt;
 
+        const promptTokens = result.usage?.prompt_tokens ?? 0;
+        const completionTokens = result.usage?.completion_tokens ?? 0;
+        const costUsd = computeCostUsd(cfg, route.resolvedModel, promptTokens, completionTokens);
+        const callerAgentId = resolveCallerAgentId(context);
         setSpanAttrs({
-          "prov.llm.prompt_tokens": result.usage?.prompt_tokens ?? 0,
-          "prov.llm.completion_tokens": result.usage?.completion_tokens ?? 0,
+          "prov.llm.prompt_tokens": promptTokens,
+          "prov.llm.completion_tokens": completionTokens,
           "prov.llm.total_tokens": result.usage?.total_tokens ?? 0,
           "prov.llm.stop_reason": result.choices?.[0]?.finish_reason ?? "unknown",
+          "cost.usd": costUsd,
+          ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
         });
 
         downstreamLogger.info({


### PR DESCRIPTION
## Summary

- **Cost + agent-id tracing**: new `src/providers/cost.ts` helpers (`computeCostUsd`, `resolveCallerAgentId`) wired into both `anthropic-sdk` and `openai-compatible` providers. Spans now carry `cost.usd` and `prov.agent.id` when available. `app.ts` threads `x-agentweave-agent-id` into the route span.
- **README: routing table fix** — added the Haiku tier that was missing after recent policy commits (#36 / 8d5eac6 / 167710b / 920d98f / 7c3f53b). Public-launch table was still showing Sonnet for lightweight traffic.
- **README: last-user-message note** — documents that Max-runtime routing evaluates only the last user message, matching current `policy.ts`.
- **.gitignore**: exclude local env backups, litellm e2e configs, `.venv-litellm/`, `run/`, and the `linkedin-draft.md` working file.

## Test plan
- [ ] `npm test` — note: 12 tests fail on `master` pre-existing (streaming / downstream spans); this PR is test-neutral, no new failures introduced.
- [ ] Verify cost.usd attribute appears in AgentWeave spans for a live request via Mux.
- [ ] Verify `prov.agent.id` appears when caller sets `x-agentweave-agent-id`.
- [ ] Visual check of README routing table vs actual `policy.ts` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)