### PR TITLE
feat(dispatcher): cross-provider failover on downstream error (#45)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,15 @@ ANTHROPIC_API_KEY=
 # For AgentWeave proxy: http://arnabsnas.local:30400
 ANTHROPIC_BASE_URL=
 
+# Cross-provider failover
+# ---
+# When >1 provider in PROVIDERS declares the same resolved model, the cost-
+# weighted cheapest is tried first; if it returns a retryable error (5xx,
+# 429, 408, 401/403, network/timeout), Mux falls over to the next cheapest.
+# FAILOVER_MAX_ATTEMPTS bounds the number of *additional* hops per request
+# (default 1 = up to 2 total provider attempts). Set 0 to disable failover.
+FAILOVER_MAX_ATTEMPTS=1
+
 # AgentWeave observability (optional — omit OTLP endpoint to disable tracing)
 # Tempo OTLP HTTP endpoint. On the NAS, Tempo listens on localhost:4318.
 AGENTWEAVE_OTLP_ENDPOINT=http://localhost:4318/v1/traces

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,12 @@ const parseNumber = (input: string | undefined, defaultValue: number): number =>
   return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
 };
 
+const parseNonNegativeInt = (input: string | undefined, defaultValue: number): number => {
+  if (!input) return defaultValue;
+  const parsed = Number.parseInt(input, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultValue;
+};
+
 const normalizeBaseUrl = (input: string | undefined): string | null => {
   if (!input?.trim()) return null;
   return input.replace(/\/+$/, "");
@@ -135,4 +141,5 @@ export const config = {
   agentweaveOtlpEndpoint: process.env.AGENTWEAVE_OTLP_ENDPOINT || null,
   agentweaveAgentId: process.env.AGENTWEAVE_AGENT_ID || "mux-router",
   providers: parseProviders(process.env.PROVIDERS),
+  failoverMaxAttempts: parseNonNegativeInt(process.env.FAILOVER_MAX_ATTEMPTS, 1),
 };

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -7,6 +7,7 @@ import pino from "pino";
 
 import { config } from "./config.js";
 import { getProvider } from "./providers/registry.js";
+import { setSpanAttrs } from "./tracing.js";
 // Side-effect import: adapter modules call registerAdapter() on load. Placed
 // here (not only in app.ts) so tests that import downstream.ts directly still
 // get adapters registered. The circular import is safe: adapters only USE
@@ -67,6 +68,26 @@ export class DownstreamRequestError extends Error {
     this.payload = payload;
   }
 }
+
+// Decide whether a downstream failure should trigger cross-provider failover.
+// Retryable: 408/429/5xx from DownstreamRequestError, 401/403 (auth may differ
+// per provider), and network-layer errors (AbortError from our timeout or
+// "fetch failed" from Node's fetch). Non-retryable: 4xx client errors (400,
+// 404, 422) — the request is malformed and won't improve on another provider.
+export const isRetryableDownstreamError = (err: unknown): boolean => {
+  if (err instanceof DownstreamRequestError) {
+    const s = err.status;
+    if (s === 408 || s === 429) return true;
+    if (s >= 500 && s < 600) return true;
+    if (s === 401 || s === 403) return true;
+    return false;
+  }
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return true;
+    if (err.message.toLowerCase().includes("fetch failed")) return true;
+  }
+  return false;
+};
 
 const estimateTokens = (req: ChatCompletionsRequest): number => {
   return Math.max(1, Math.ceil(JSON.stringify(req.messages).length / 4));
@@ -512,22 +533,86 @@ export const toOpenAIResponse = (response: Message, model: string): DownstreamRe
   };
 };
 
+// Build the ordered provider chain for this request: primary followed by up
+// to config.failoverMaxAttempts fallbacks. Legacy callers that pass a route
+// without fallbackProviderIds get a single-entry chain.
+const buildProviderChain = (route: RouteDecision): string[] => {
+  const primary = route.providerId || "default";
+  const fallbacks = route.fallbackProviderIds ?? [];
+  const hops = Math.max(0, Math.min(config.failoverMaxAttempts, fallbacks.length));
+  return [primary, ...fallbacks.slice(0, hops)];
+};
+
+const annotateFailoverHop = (
+  i: number,
+  id: string,
+  failedProviders: string[],
+  lastError: unknown,
+): void => {
+  setSpanAttrs({
+    "prov.failover.attempt": i,
+    "prov.failover.failed_providers": failedProviders.join(","),
+    "prov.failover.active_provider": id,
+    "prov.route.provider_id": id,
+  });
+  downstreamLogger.warn({
+    event: "mux.failover_hop",
+    from: failedProviders[failedProviders.length - 1],
+    to: id,
+    attempt: i,
+    reason:
+      lastError instanceof DownstreamRequestError
+        ? `status=${lastError.status}`
+        : lastError instanceof Error
+          ? lastError.name
+          : "unknown",
+  });
+};
+
 export const callDownstream = async (
   req: ChatCompletionsRequest,
   route: RouteDecision,
   context?: DownstreamRequestContext,
 ): Promise<DownstreamResponse> => {
-  const providerId = route.providerId || "default";
-  const provider = getProvider(providerId);
-  if (!provider) {
-    if (providerId === "default" && config.downstreamMockFallbackEnabled) {
-      return buildMockResponse(req, route);
+  const chain = buildProviderChain(route);
+  const failedProviders: string[] = [];
+  let lastError: unknown;
+
+  for (let i = 0; i < chain.length; i++) {
+    const providerId = chain[i]!;
+    const provider = getProvider(providerId);
+    if (!provider) {
+      // Preserve legacy mock-fallback behavior only when primary "default"
+      // is unregistered AND we're on the first attempt with no fallbacks —
+      // otherwise the request intended a real provider and should error.
+      if (
+        i === 0 &&
+        chain.length === 1 &&
+        providerId === "default" &&
+        config.downstreamMockFallbackEnabled
+      ) {
+        return buildMockResponse(req, route);
+      }
+      lastError = new DownstreamNotConfiguredError(
+        `provider '${providerId}' is not registered (no matching entry in PROVIDERS env or legacy DOWNSTREAM_*)`,
+      );
+      failedProviders.push(providerId);
+      if (i === chain.length - 1) throw lastError;
+      continue;
     }
-    throw new DownstreamNotConfiguredError(
-      `provider '${providerId}' is not registered (no matching entry in PROVIDERS env or legacy DOWNSTREAM_*)`,
-    );
+
+    if (i > 0) annotateFailoverHop(i, providerId, failedProviders, lastError);
+
+    try {
+      return (await provider.call(req, route, context)) as DownstreamResponse;
+    } catch (err) {
+      lastError = err;
+      failedProviders.push(providerId);
+      if (!isRetryableDownstreamError(err)) throw err;
+      if (i === chain.length - 1) throw err;
+    }
   }
-  return provider.call(req, route, context) as Promise<DownstreamResponse>;
+  throw lastError ?? new DownstreamNotConfiguredError("no providers available");
 };
 
 // --- Streaming path ------------------------------------------------------
@@ -792,16 +877,46 @@ export const streamDownstream = async (
   res: express.Response,
   context?: DownstreamRequestContext,
 ): Promise<void> => {
-  const providerId = route.providerId || "default";
-  const provider = getProvider(providerId);
-  if (!provider) {
-    if (providerId === "default" && config.downstreamMockFallbackEnabled) {
-      emitDownstreamResponseAsSse(res, buildMockResponse(req, route));
-      return;
+  const chain = buildProviderChain(route);
+  const failedProviders: string[] = [];
+  let lastError: unknown;
+
+  for (let i = 0; i < chain.length; i++) {
+    const providerId = chain[i]!;
+    const provider = getProvider(providerId);
+    if (!provider) {
+      if (
+        i === 0 &&
+        chain.length === 1 &&
+        providerId === "default" &&
+        config.downstreamMockFallbackEnabled
+      ) {
+        emitDownstreamResponseAsSse(res, buildMockResponse(req, route));
+        return;
+      }
+      lastError = new DownstreamNotConfiguredError(
+        `provider '${providerId}' is not registered (no matching entry in PROVIDERS env or legacy DOWNSTREAM_*)`,
+      );
+      failedProviders.push(providerId);
+      if (i === chain.length - 1) throw lastError;
+      continue;
     }
-    throw new DownstreamNotConfiguredError(
-      `provider '${providerId}' is not registered (no matching entry in PROVIDERS env or legacy DOWNSTREAM_*)`,
-    );
+
+    if (i > 0) annotateFailoverHop(i, providerId, failedProviders, lastError);
+
+    try {
+      await provider.stream(req, route, res, context);
+      return;
+    } catch (err) {
+      lastError = err;
+      failedProviders.push(providerId);
+      // Once bytes have been written to the client we cannot failover — the
+      // adapter is responsible for emitting an in-band error chunk and
+      // ending the SSE stream. Rethrow so the app layer logs it.
+      if (res.headersSent) throw err;
+      if (!isRetryableDownstreamError(err)) throw err;
+      if (i === chain.length - 1) throw err;
+    }
   }
-  return provider.stream(req, route, res, context);
+  throw lastError ?? new DownstreamNotConfiguredError("no providers available");
 };

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -5,12 +5,13 @@ import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
 
 type ProviderSelection = {
   providerId: string;
+  fallbacks: string[]; // cost-ordered, primary excluded
   costWeighted: boolean;
 };
 
-// Pick the cheapest registered provider that declares the given model.
-// When more than one matches, cost-weighted selection fires and the caller
-// annotates the route reason with "+cost_weighted".
+// Rank the registered providers that declare the given model by combined
+// input+output cost. The cheapest becomes the primary; the rest form the
+// failover chain. When only one provider matches, fallbacks is empty.
 const selectProviderForModel = (
   resolvedModel: string,
   providers: Provider[],
@@ -31,26 +32,28 @@ const selectProviderForModel = (
   const sorted = [...candidates].sort((a, b) => cost(a) - cost(b));
   return {
     providerId: sorted[0]!.id,
-    costWeighted: candidates.length > 1,
+    fallbacks: sorted.slice(1).map((p) => p.id),
+    costWeighted: sorted.length > 1,
   };
 };
 
-// Resolve providerId + final routeReason. Any single provider registered for
-// the model wins without mutating reason; multiple → cheapest wins and reason
-// gains +cost_weighted. No match → "default" (the dispatcher's mock-fallback
-// or a legacy synthesized provider picks it up).
+// Resolve providerId + fallback chain + final routeReason. Any single provider
+// registered for the model wins without mutating reason; multiple → cheapest
+// wins and reason gains +cost_weighted. No match → "default" (the dispatcher's
+// mock-fallback or a legacy synthesized provider picks it up).
 const applyProviderSelection = (
-  decision: Omit<RouteDecision, "providerId">,
+  decision: Omit<RouteDecision, "providerId" | "fallbackProviderIds">,
   providers?: Provider[],
 ): RouteDecision => {
   const pool = providers ?? listProviders();
   const selection = selectProviderForModel(decision.resolvedModel, pool);
   if (!selection) {
-    return { ...decision, providerId: "default" };
+    return { ...decision, providerId: "default", fallbackProviderIds: [] };
   }
   return {
     ...decision,
     providerId: selection.providerId,
+    fallbackProviderIds: selection.fallbacks,
     routeReason: selection.costWeighted
       ? `${decision.routeReason}+cost_weighted`
       : decision.routeReason,
@@ -153,8 +156,9 @@ export const resolveRoute = (
   providers?: Provider[],
 ): RouteDecision => {
   const requestedModel = req.model;
-  const finalize = (decision: Omit<RouteDecision, "providerId">): RouteDecision =>
-    applyProviderSelection(decision, providers);
+  const finalize = (
+    decision: Omit<RouteDecision, "providerId" | "fallbackProviderIds">,
+  ): RouteDecision => applyProviderSelection(decision, providers);
 
   if (isAnthropicModel(requestedModel)) {
     const anthropicMapped = config.anthropicModelMap[requestedModel];

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,4 +60,8 @@ export type RouteDecision = {
   // The registered provider identifier the dispatcher uses to look up a
   // concrete backend. Defaults to "default" for legacy single-provider setups.
   providerId: string;
+  // Cost-ordered fallback chain (primary excluded). When the primary returns
+  // a retryable error, the dispatcher walks this list up to
+  // config.failoverMaxAttempts hops. Empty when only one provider matches.
+  fallbackProviderIds: string[];
 };

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -1772,3 +1772,338 @@ describe("streamDownstream", () => {
     }
   });
 });
+
+// --- cross-provider failover (issue #45) ------------------------------------
+
+describe("callDownstream — failover", () => {
+  const failoverRoute: RouteDecision = {
+    requestedModel: "gpt-4o",
+    resolvedModel: "gpt-4o-mini",
+    routeReason: "heuristic:test+cost_weighted",
+    provider: "openai-compatible",
+    backendTarget: "http://a/v1",
+    providerId: "a",
+    fallbackProviderIds: ["b"],
+  };
+
+  const setupTwoProviders = () => {
+    const previousProviders = config.providers;
+    const previousAttempts = config.failoverMaxAttempts;
+    config.providers = [
+      {
+        id: "a",
+        kind: "openai-compatible",
+        baseUrl: "http://a/v1",
+        auth: { mode: "bearer", apiKey: "key-a" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.1, costOutputUsdPerMTok: 0.4 }],
+      },
+      {
+        id: "b",
+        kind: "openai-compatible",
+        baseUrl: "http://b/v1",
+        auth: { mode: "bearer", apiKey: "key-b" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.2, costOutputUsdPerMTok: 0.5 }],
+      },
+    ];
+    config.failoverMaxAttempts = 1;
+    __resetAnthropicClientForTests();
+    return () => {
+      config.providers = previousProviders;
+      config.failoverMaxAttempts = previousAttempts;
+      __resetAnthropicClientForTests();
+    };
+  };
+
+  const okJsonResponse = (model: string, content: string): Response =>
+    new Response(
+      JSON.stringify({
+        id: "chatcmpl-x",
+        object: "chat.completion",
+        created: 1,
+        model,
+        choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  it("retries on 5xx from primary and succeeds with fallback", async () => {
+    const restore = setupTwoProviders();
+    try {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.startsWith("http://a/")) {
+            return new Response(JSON.stringify({ error: { message: "boom" } }), {
+              status: 503,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          if (url.startsWith("http://b/")) {
+            return okJsonResponse("gpt-4o-mini", "from-b");
+          }
+          throw new Error(`unexpected url: ${url}`);
+        });
+
+      const result = await callDownstream(requestPayload, failoverRoute);
+      expect(result.choices[0]?.message.content).toBe("from-b");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not retry on 4xx client error from primary", async () => {
+    const restore = setupTwoProviders();
+    try {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.startsWith("http://a/")) {
+            return new Response(JSON.stringify({ error: { message: "bad request" } }), {
+              status: 400,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          throw new Error(`unexpected url: ${url}`);
+        });
+
+      await expect(callDownstream(requestPayload, failoverRoute)).rejects.toBeInstanceOf(
+        DownstreamRequestError,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces the last error when all providers fail", async () => {
+    const restore = setupTwoProviders();
+    try {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        const status = url.startsWith("http://a/") ? 503 : 504;
+        return new Response(JSON.stringify({ error: { message: "down" } }), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+      await expect(callDownstream(requestPayload, failoverRoute)).rejects.toSatisfy(
+        (err) => err instanceof DownstreamRequestError && err.status === 504,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("disables failover when FAILOVER_MAX_ATTEMPTS=0", async () => {
+    const restore = setupTwoProviders();
+    try {
+      config.failoverMaxAttempts = 0;
+      __resetAnthropicClientForTests();
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () =>
+          new Response(JSON.stringify({ error: { message: "boom" } }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      await expect(callDownstream(requestPayload, failoverRoute)).rejects.toSatisfy(
+        (err) => err instanceof DownstreamRequestError && err.status === 503,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("logs a mux.failover_hop event on hop", async () => {
+    const restore = setupTwoProviders();
+    try {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("http://a/")) {
+          return new Response("x", { status: 503 });
+        }
+        return okJsonResponse("gpt-4o-mini", "hi");
+      });
+      const warnSpy = vi.spyOn(downstreamLogger, "warn");
+
+      await callDownstream(requestPayload, failoverRoute);
+
+      const hopLog = warnSpy.mock.calls
+        .map((c) => c[0] as Record<string, unknown>)
+        .find((c) => c.event === "mux.failover_hop");
+      expect(hopLog).toBeDefined();
+      expect(hopLog?.from).toBe("a");
+      expect(hopLog?.to).toBe("b");
+      expect(hopLog?.attempt).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("streamDownstream — failover", () => {
+  const streamRoute: RouteDecision = {
+    requestedModel: "gpt-4o",
+    resolvedModel: "gpt-4o-mini",
+    routeReason: "heuristic:test+cost_weighted",
+    provider: "openai-compatible",
+    backendTarget: "http://a/v1",
+    providerId: "a",
+    fallbackProviderIds: ["b"],
+  };
+
+  const setupTwoProviders = () => {
+    const previousProviders = config.providers;
+    const previousAttempts = config.failoverMaxAttempts;
+    config.providers = [
+      {
+        id: "a",
+        kind: "openai-compatible",
+        baseUrl: "http://a/v1",
+        auth: { mode: "bearer", apiKey: "key-a" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.1, costOutputUsdPerMTok: 0.4 }],
+      },
+      {
+        id: "b",
+        kind: "openai-compatible",
+        baseUrl: "http://b/v1",
+        auth: { mode: "bearer", apiKey: "key-b" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.2, costOutputUsdPerMTok: 0.5 }],
+      },
+    ];
+    config.failoverMaxAttempts = 1;
+    __resetAnthropicClientForTests();
+    return () => {
+      config.providers = previousProviders;
+      config.failoverMaxAttempts = previousAttempts;
+      __resetAnthropicClientForTests();
+    };
+  };
+
+  const makeStreamRes = () => {
+    const res: any = {
+      statusCode: 0,
+      headersSent: false,
+      headers: {} as Record<string, string>,
+      writes: [] as string[],
+      ended: false,
+      _listeners: {} as Record<string, Array<() => void>>,
+      status(code: number) { res.statusCode = code; return res; },
+      setHeader(k: string, v: string) { res.headers[k] = v; },
+      getHeader(k: string) { return res.headers[k]; },
+      write(chunk: string) { res.headersSent = true; res.writes.push(chunk); return true; },
+      end() { res.ended = true; },
+      once(event: string, cb: () => void) { (res._listeners[event] ||= []).push(cb); },
+      off(event: string, cb: () => void) {
+        const list = res._listeners[event];
+        if (!list) return;
+        const i = list.indexOf(cb);
+        if (i >= 0) list.splice(i, 1);
+      },
+      emit(event: string) { for (const cb of res._listeners[event] ?? []) cb(); },
+    };
+    return res;
+  };
+
+  const sseOk = (content: string): Response => {
+    const encoder = new TextEncoder();
+    const frames = [
+      `data: ${JSON.stringify({
+        id: "c", object: "chat.completion.chunk", created: 1, model: "gpt-4o-mini",
+        choices: [{ index: 0, delta: { role: "assistant", content }, finish_reason: null }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "c", object: "chat.completion.chunk", created: 1, model: "gpt-4o-mini",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+      "data: [DONE]\n\n",
+    ];
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const f of frames) controller.enqueue(encoder.encode(f));
+        controller.close();
+      },
+    });
+    return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+  };
+
+  it("retries pre-stream on 503 and streams from fallback", async () => {
+    const restore = setupTwoProviders();
+    try {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("http://a/")) {
+          return new Response(JSON.stringify({ error: { message: "boom" } }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return sseOk("hi from b");
+      });
+
+      const res = makeStreamRes();
+      await streamDownstream(
+        { ...requestPayload, stream: true },
+        streamRoute,
+        res as unknown as import("express").Response,
+      );
+
+      const joined = res.writes.join("");
+      expect(joined).toContain("hi from b");
+      expect(joined).toContain("[DONE]");
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not failover on a mid-stream non-retryable error from the primary", async () => {
+    const restore = setupTwoProviders();
+    try {
+      // Primary opens a 200 stream but the body errors mid-pull with a plain
+      // Error (not a retryable class). Dispatcher must rethrow without calling
+      // provider B, even if res.headersSent has not yet flipped — because the
+      // error itself is non-retryable.
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.startsWith("http://a/")) {
+            const stream = new ReadableStream({
+              pull(controller) {
+                controller.error(new Error("mid-stream boom"));
+              },
+            });
+            return new Response(stream, {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            });
+          }
+          throw new Error("provider b must not be called");
+        });
+
+      const res = makeStreamRes();
+      await expect(
+        streamDownstream(
+          { ...requestPayload, stream: true },
+          streamRoute,
+          res as unknown as import("express").Response,
+        ),
+      ).rejects.toThrow(/mid-stream boom/);
+
+      // Provider A was called; provider B was NOT.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/^http:\/\/a\//);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -280,6 +280,8 @@ describe("resolveRoute", () => {
     expect(route.resolvedModel).toBe("claude-sonnet-4-6");
     expect(route.providerId).toBe("cheap");
     expect(route.routeReason).toBe("heuristic:max_anthropic_coding+cost_weighted");
+    // Primary excluded; more-expensive provider queued as fallback for #45
+    expect(route.fallbackProviderIds).toEqual(["expensive"]);
 
     config.modelMap = previousModelMap;
     config.anthropicModelMap = previousAnthropicModelMap;
@@ -312,6 +314,7 @@ describe("resolveRoute", () => {
 
     expect(route.providerId).toBe("only-one");
     expect(route.routeReason).toBe("heuristic:max_anthropic_coding");
+    expect(route.fallbackProviderIds).toEqual([]);
 
     config.modelMap = previousModelMap;
     config.anthropicModelMap = previousAnthropicModelMap;


### PR DESCRIPTION
## Summary

Closes #45. When >1 provider serves the same resolved model, Mux now walks the cost-ordered chain on a retryable downstream error instead of bubbling the failure to the client.

- `RouteDecision.fallbackProviderIds` — cost-ordered, primary excluded, populated by the policy
- `callDownstream` / `streamDownstream` loop the chain up to `FAILOVER_MAX_ATTEMPTS` hops (default 1, env-configurable; 0 disables)
- Retryable: 5xx, 429, 408, 401/403, network-layer (`AbortError`, `fetch failed`). Non-retryable 4xx (400/404/422) throw immediately
- Streaming guard: once `res.headersSent` flips, failover is skipped — we can't emit two diverging SSE streams; the adapter's in-band error chunk handles it
- Annotations on each hop: `mux.failover_hop` log + span attrs `prov.failover.attempt`, `prov.failover.failed_providers`, `prov.failover.active_provider`, and `prov.route.provider_id` is overwritten so dashboards show the provider that actually served

## Test plan

- [x] `npx vitest run` — 77/77 pass (70 baseline + 5 failover dispatch + 2 streaming failover; +2 policy assertions on `fallbackProviderIds`)
- [x] `tsc --noEmit` — clean
- [x] Deployed to NAS, health OK
- [x] Live smoke: temporarily seeded a cheaper broken provider (`http://127.0.0.1:1`) serving `claude-haiku-4-5-20251001`. Request went to `broken-failover-test` → TypeError (undici fetch failed) → `mux.failover_hop` logged → `default` Anthropic provider served the real response. `.env` reverted post-test.

## Out of scope (deferred to #39 Phase 4)

- Per-model/per-provider failover chains via config
- Provider health tracking / circuit breakers / backoff
- Per-hop latency spans
- Failing over *mid-stream* (buffering + swap) — explicitly not supported; documented as known limitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)