### PR TITLE
feat(downstream): Anthropic prompt caching via cache_control injection (closes #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,43 @@ curl -s http://localhost:8787/v1/chat/completions \
 | `ANTHROPIC_OAUTH_TOKEN` | — | OAuth token (preferred for anthropic-sdk) |
 | `ANTHROPIC_API_KEY` | — | API key fallback for anthropic-sdk |
 | `ANTHROPIC_BASE_URL` | — | Override Anthropic API URL (supports proxies) |
+| `MUX_ANTHROPIC_PROMPT_CACHE` | `true` | Inject Anthropic ephemeral `cache_control` breakpoints on the translated request (system, tools, history) |
+
+## Prompt caching (Anthropic)
+
+When the downstream is Anthropic, Mux transparently injects ephemeral
+`cache_control` breakpoints on the translated request so multi-turn agents
+get a 90% discount on re-used input tokens (5-minute TTL).
+
+**What gets cached**
+- the translated system prompt (one breakpoint on the single text block),
+- the full tools block (breakpoint on the last tool),
+- the conversation history (breakpoint on the last content block of the
+  last message; skipped when there's only one turn).
+
+**Reading cache stats.** Anthropic's `cache_read_input_tokens` is surfaced
+on responses as `usage.prompt_tokens_details.cached_tokens`, and both
+cache-read and cache-creation tokens are rolled into `usage.prompt_tokens`
+so billable-prompt size reflects the true transcript:
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 5400,
+    "completion_tokens": 20,
+    "total_tokens": 5420,
+    "prompt_tokens_details": { "cached_tokens": 5000 }
+  }
+}
+```
+
+**Cost model.** Anthropic charges a 25% surcharge on cache *writes* and a
+90% discount on cache *reads*, with a 5-minute TTL. For a client that
+re-uses the same system + tools across turns, turn 1 pays the write
+surcharge and turns 2+ hit cache — net cost drops sharply within a single
+session.
+
+**Opt out.** Set `MUX_ANTHROPIC_PROMPT_CACHE=false` to disable.
 
 ## Running tests
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -142,4 +142,12 @@ export const config = {
   agentweaveAgentId: process.env.AGENTWEAVE_AGENT_ID || "mux-router",
   providers: parseProviders(process.env.PROVIDERS),
   failoverMaxAttempts: parseNonNegativeInt(process.env.FAILOVER_MAX_ATTEMPTS, 1),
+  // Inject Anthropic ephemeral prompt-cache breakpoints in the OpenAI →
+  // Anthropic translator (system prompt, tools, history). On by default —
+  // correctly-formed requests only benefit. Opt out with
+  // MUX_ANTHROPIC_PROMPT_CACHE=false if a downstream edge case surfaces.
+  anthropicPromptCacheEnabled: parseBoolean(
+    process.env.MUX_ANTHROPIC_PROMPT_CACHE,
+    true,
+  ),
 };

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -47,8 +47,17 @@ export type DownstreamResponse = {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    prompt_tokens_details?: {
+      cached_tokens: number;
+    };
   };
 };
+
+// Anthropic ephemeral prompt-cache breakpoint. Attaching this to a content
+// block tells Anthropic to cache the prefix up to and including that block
+// for ~5 minutes; subsequent requests with the same prefix read from cache
+// at ~90% discount. See issue #49.
+export type AnthropicCacheControl = { type: "ephemeral" };
 
 export class DownstreamNotConfiguredError extends Error {
   constructor(message = "Downstream is not configured") {
@@ -325,8 +334,26 @@ const openAIToolCallToToolUse = (call: OpenAIToolCall): AnthropicToolUseBlock =>
   };
 };
 
-export const toAnthropicInput = (req: ChatCompletionsRequest): {
-  system?: string;
+export type AnthropicSystemBlock = {
+  type: "text";
+  text: string;
+  cache_control?: AnthropicCacheControl;
+};
+
+export type ToAnthropicInputOptions = {
+  // When true, inject ephemeral cache_control breakpoints at:
+  //   1. the (single) system text block, and
+  //   2. the last content block of the last message — provided history has
+  //      at least 2 messages. Single-message history skips (2) because
+  //      there's no prior turn whose prefix we'd be re-using.
+  cacheControl?: boolean;
+};
+
+export const toAnthropicInput = (
+  req: ChatCompletionsRequest,
+  opts: ToAnthropicInputOptions = {},
+): {
+  system?: string | AnthropicSystemBlock[];
   messages: AnthropicInputMessage[];
 } => {
   const system = req.messages
@@ -383,14 +410,53 @@ export const toAnthropicInput = (req: ChatCompletionsRequest): {
     messages.push({ role, content: blocks });
   }
 
+  // Cache-control injection. Kept out of the hot loop so the non-cache path
+  // (opts.cacheControl !== true) is a no-op.
+  if (opts.cacheControl) {
+    // Breakpoint on last block of last message — caches the full history
+    // prefix so multi-turn loops hit cache from turn 2 onwards. Skip when
+    // history is a single turn: nothing to reuse yet.
+    if (messages.length >= 2) {
+      const last = messages[messages.length - 1]!;
+      const lastBlock = last.content[last.content.length - 1];
+      if (lastBlock) {
+        (lastBlock as { cache_control?: AnthropicCacheControl }).cache_control = {
+          type: "ephemeral",
+        };
+      }
+    }
+
+    if (system) {
+      return {
+        system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+        messages,
+      };
+    }
+    return { system: undefined, messages };
+  }
+
   return { system: system || undefined, messages };
+};
+
+export type AnthropicToolDef = {
+  name: string;
+  description?: string;
+  input_schema: Record<string, unknown>;
+  cache_control?: AnthropicCacheControl;
+};
+
+export type TranslateToolsOptions = {
+  // When true, attach ephemeral cache_control to the LAST translated tool —
+  // Anthropic caches the entire tools block up to the last marker. See #49.
+  cacheControl?: boolean;
 };
 
 export const translateToolsToAnthropic = (
   tools: OpenAIToolDef[] | undefined,
-): Array<{ name: string; description?: string; input_schema: Record<string, unknown> }> | undefined => {
+  opts: TranslateToolsOptions = {},
+): AnthropicToolDef[] | undefined => {
   if (!Array.isArray(tools) || tools.length === 0) return undefined;
-  const translated = tools
+  const translated: AnthropicToolDef[] = tools
     .filter(
       (t): t is OpenAIToolDef =>
         !!t && t.type === "function" && !!t.function && typeof t.function.name === "string",
@@ -401,7 +467,7 @@ export const translateToolsToAnthropic = (
         params && typeof params === "object" && !Array.isArray(params)
           ? (params as Record<string, unknown>)
           : { type: "object", properties: {} };
-      const out: { name: string; description?: string; input_schema: Record<string, unknown> } = {
+      const out: AnthropicToolDef = {
         name: t.function.name,
         input_schema,
       };
@@ -410,7 +476,11 @@ export const translateToolsToAnthropic = (
       }
       return out;
     });
-  return translated.length > 0 ? translated : undefined;
+  if (translated.length === 0) return undefined;
+  if (opts.cacheControl) {
+    translated[translated.length - 1]!.cache_control = { type: "ephemeral" };
+  }
+  return translated;
 };
 
 export const translateToolChoiceToAnthropic = (
@@ -508,6 +578,31 @@ export const toOpenAIResponse = (response: Message, model: string): DownstreamRe
 
   const inputTokens = response.usage.input_tokens;
   const outputTokens = response.usage.output_tokens;
+  // Anthropic reports cached tokens in separate buckets outside input_tokens.
+  // For an OpenAI-shaped client to see the true billable prompt size, we roll
+  // them back into prompt_tokens and expose the cache-hit portion via the
+  // canonical prompt_tokens_details.cached_tokens field. See #49.
+  const rawUsage = response.usage as {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number | null;
+    cache_read_input_tokens?: number | null;
+  };
+  const cacheCreation = rawUsage.cache_creation_input_tokens ?? 0;
+  const cacheRead = rawUsage.cache_read_input_tokens ?? 0;
+  const hasCacheFields =
+    rawUsage.cache_creation_input_tokens != null ||
+    rawUsage.cache_read_input_tokens != null;
+
+  const promptTokens = inputTokens + cacheCreation + cacheRead;
+  const usage: NonNullable<DownstreamResponse["usage"]> = {
+    prompt_tokens: promptTokens,
+    completion_tokens: outputTokens,
+    total_tokens: promptTokens + outputTokens,
+  };
+  if (hasCacheFields) {
+    usage.prompt_tokens_details = { cached_tokens: cacheRead };
+  }
 
   return {
     id: response.id,
@@ -525,11 +620,7 @@ export const toOpenAIResponse = (response: Message, model: string): DownstreamRe
         finish_reason: anthropicStopReasonToOpenAI(response.stop_reason),
       },
     ],
-    usage: {
-      prompt_tokens: inputTokens,
-      completion_tokens: outputTokens,
-      total_tokens: inputTokens + outputTokens,
-    },
+    usage,
   };
 };
 

--- a/src/providers/anthropic-sdk.ts
+++ b/src/providers/anthropic-sdk.ts
@@ -4,6 +4,7 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type express from "express";
 
+import { config } from "../config.js";
 import { setSpanAttrs, withLlmSpan } from "../tracing.js";
 import { computeCostUsd, resolveCallerAgentId } from "./cost.js";
 import type { ChatCompletionsRequest, RouteDecision } from "../types.js";
@@ -112,21 +113,37 @@ export const createAnthropicSdkProvider = (cfg: ProviderConfig): Provider => {
     streamed: boolean,
   ): { client: Anthropic; params: Record<string, unknown> } => {
     const client = getClient();
-    const { system, messages } = toAnthropicInput(req);
+    const cacheControl = config.anthropicPromptCacheEnabled;
+    const { system, messages } = toAnthropicInput(req, { cacheControl });
     const isOauth = cfg.auth.mode === "anthropic-oauth";
-    const systemBlocks = isOauth
-      ? [
-          { type: "text" as const, text: "You are Claude Code, Anthropic's official CLI for Claude." },
-          ...(system ? [{ type: "text" as const, text: system }] : []),
-        ]
-      : system;
+
+    // Normalize to the shape Anthropic's SDK accepts: string | block[].
+    // When cacheControl is on, toAnthropicInput already returns blocks. The
+    // oauth branch must always prepend the Claude Code identity prefix, and
+    // merge with whatever toAnthropicInput returned.
+    let systemBlocks: string | Array<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }> | undefined;
+    if (isOauth) {
+      const prefix = {
+        type: "text" as const,
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      };
+      if (Array.isArray(system)) {
+        systemBlocks = [prefix, ...system];
+      } else if (typeof system === "string" && system.length > 0) {
+        systemBlocks = [prefix, { type: "text", text: system }];
+      } else {
+        systemBlocks = [prefix];
+      }
+    } else {
+      systemBlocks = system;
+    }
 
     const maxTokens = req.max_tokens ?? DEFAULT_ANTHROPIC_MAX_TOKENS;
     const systemLength = Array.isArray(systemBlocks)
       ? systemBlocks.reduce((sum, b) => sum + b.text.length, 0)
       : (systemBlocks?.length ?? 0);
 
-    const anthropicTools = translateToolsToAnthropic(req.tools);
+    const anthropicTools = translateToolsToAnthropic(req.tools, { cacheControl });
     const anthropicToolChoice = translateToolChoiceToAnthropic(req.tool_choice);
 
     downstreamLogger.info({

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -1035,11 +1035,13 @@ describe("callDownstream — tools forwarding to Anthropic SDK", () => {
     );
 
     const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body));
+    // Last (here: only) tool carries ephemeral cache_control by default — see #49.
     expect(body.tools).toEqual([
       {
         name: "gpu_status",
         description: "Report GPU state",
         input_schema: { type: "object", properties: {} },
+        cache_control: { type: "ephemeral" },
       },
     ]);
     expect(body.tool_choice).toEqual({ type: "auto" });
@@ -2105,5 +2107,219 @@ describe("streamDownstream — failover", () => {
     } finally {
       restore();
     }
+  });
+});
+
+describe("prompt caching (cache_control injection)", () => {
+  const EPH = { type: "ephemeral" } as const;
+
+  it("returns system as an ephemeral-cached text block array when cacheControl enabled", () => {
+    const { system } = toAnthropicInput(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [
+          { role: "system", content: "you are terse" },
+          { role: "user", content: "hi" },
+        ],
+      },
+      { cacheControl: true },
+    );
+
+    expect(Array.isArray(system)).toBe(true);
+    expect(system).toEqual([
+      { type: "text", text: "you are terse", cache_control: EPH },
+    ]);
+  });
+
+  it("returns system as a plain string when cacheControl disabled", () => {
+    const { system } = toAnthropicInput(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [
+          { role: "system", content: "you are terse" },
+          { role: "user", content: "hi" },
+        ],
+      },
+      { cacheControl: false },
+    );
+
+    expect(system).toBe("you are terse");
+  });
+
+  it("omits system entirely when there is no system text, cacheControl enabled", () => {
+    const { system } = toAnthropicInput(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { cacheControl: true },
+    );
+
+    expect(system).toBeUndefined();
+  });
+
+  it("attaches cache_control to the last content block of the last message when history has >=2 messages", () => {
+    const { messages } = toAnthropicInput(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [
+          { role: "user", content: "q1" },
+          { role: "assistant", content: "a1" },
+          { role: "user", content: "q2" },
+        ],
+      },
+      { cacheControl: true },
+    );
+
+    expect(messages).toHaveLength(3);
+    const last = messages[messages.length - 1]!;
+    const lastBlock = last.content[last.content.length - 1]! as {
+      type: string;
+      cache_control?: typeof EPH;
+    };
+    expect(lastBlock.cache_control).toEqual(EPH);
+
+    // Earlier messages are NOT marked.
+    for (let i = 0; i < messages.length - 1; i++) {
+      for (const b of messages[i]!.content as Array<{ cache_control?: unknown }>) {
+        expect(b.cache_control).toBeUndefined();
+      }
+    }
+  });
+
+  it("skips the history breakpoint when there is a single message", () => {
+    const { messages } = toAnthropicInput(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "only-one" }],
+      },
+      { cacheControl: true },
+    );
+
+    expect(messages).toHaveLength(1);
+    const only = messages[0]!;
+    const block = only.content[only.content.length - 1]! as { cache_control?: unknown };
+    expect(block.cache_control).toBeUndefined();
+  });
+
+  it("does not inject cache_control on messages when cacheControl disabled", () => {
+    const { messages } = toAnthropicInput(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [
+          { role: "user", content: "q1" },
+          { role: "assistant", content: "a1" },
+          { role: "user", content: "q2" },
+        ],
+      },
+      { cacheControl: false },
+    );
+
+    for (const m of messages) {
+      for (const b of m.content as Array<{ cache_control?: unknown }>) {
+        expect(b.cache_control).toBeUndefined();
+      }
+    }
+  });
+
+  it("marks only the last tool with cache_control when cacheControl enabled", () => {
+    const tools: OpenAIToolDef[] = [
+      { type: "function", function: { name: "a", parameters: { type: "object", properties: {} } } },
+      { type: "function", function: { name: "b", parameters: { type: "object", properties: {} } } },
+      { type: "function", function: { name: "c", parameters: { type: "object", properties: {} } } },
+    ];
+    const result = translateToolsToAnthropic(tools, { cacheControl: true });
+    expect(result).toHaveLength(3);
+    expect((result![0] as { cache_control?: unknown }).cache_control).toBeUndefined();
+    expect((result![1] as { cache_control?: unknown }).cache_control).toBeUndefined();
+    expect((result![2] as { cache_control?: unknown }).cache_control).toEqual(EPH);
+  });
+
+  it("leaves tools untouched when cacheControl disabled", () => {
+    const tools: OpenAIToolDef[] = [
+      { type: "function", function: { name: "a", parameters: { type: "object", properties: {} } } },
+      { type: "function", function: { name: "b", parameters: { type: "object", properties: {} } } },
+    ];
+    const result = translateToolsToAnthropic(tools, { cacheControl: false });
+    for (const t of result!) {
+      expect((t as { cache_control?: unknown }).cache_control).toBeUndefined();
+    }
+  });
+
+  it("preserves the existing default behaviour when called without options", () => {
+    // Back-compat: existing callers that omit options see no cache_control.
+    const { system, messages } = toAnthropicInput({
+      model: "claude-sonnet-4-6",
+      messages: [
+        { role: "system", content: "s" },
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+      ],
+    });
+    expect(system).toBe("s");
+    for (const m of messages) {
+      for (const b of m.content as Array<{ cache_control?: unknown }>) {
+        expect(b.cache_control).toBeUndefined();
+      }
+    }
+
+    const tools = translateToolsToAnthropic([
+      { type: "function", function: { name: "a", parameters: { type: "object", properties: {} } } },
+    ]);
+    expect((tools![0] as { cache_control?: unknown }).cache_control).toBeUndefined();
+  });
+});
+
+describe("toOpenAIResponse — cache usage surfacing", () => {
+  it("maps cache_read_input_tokens into prompt_tokens_details.cached_tokens and rolls cache tokens into prompt_tokens", () => {
+    const response = toOpenAIResponse(
+      {
+        id: "msg_cache",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_creation_input_tokens: 300,
+          cache_read_input_tokens: 5000,
+        },
+      } as unknown as Parameters<typeof toOpenAIResponse>[0],
+      "claude-sonnet-4-6",
+    );
+
+    expect(response.usage).toBeDefined();
+    // input (100) + cache_read (5000) + cache_creation (300) = 5400
+    expect(response.usage!.prompt_tokens).toBe(5400);
+    expect(response.usage!.completion_tokens).toBe(20);
+    expect(response.usage!.total_tokens).toBe(5420);
+    expect(
+      (response.usage as { prompt_tokens_details?: { cached_tokens?: number } })
+        .prompt_tokens_details?.cached_tokens,
+    ).toBe(5000);
+  });
+
+  it("omits prompt_tokens_details when no cache fields are present", () => {
+    const response = toOpenAIResponse(
+      {
+        id: "msg_nocache",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 3 },
+      } as unknown as Parameters<typeof toOpenAIResponse>[0],
+      "claude-sonnet-4-6",
+    );
+
+    expect(response.usage!.prompt_tokens).toBe(10);
+    expect(
+      (response.usage as { prompt_tokens_details?: unknown }).prompt_tokens_details,
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #49.

Injects ephemeral Anthropic `cache_control` breakpoints on the OpenAI → Anthropic translation path so clients going through Mux (notably `agent-max`) get the 90% cache-read discount without any client-side change.

- **Breakpoint 1** — system prompt (single text block)
- **Breakpoint 2** — last entry of the translated `tools` array (Anthropic caches the full tools block up to the last marker)
- **Breakpoint 3** — last content block of the last message; skipped on single-turn history (nothing to re-use yet)
- Surfaces `cache_read_input_tokens` on responses as `usage.prompt_tokens_details.cached_tokens`, and rolls cache-read + cache-creation into `usage.prompt_tokens` so billable prompt size reflects the true transcript
- Gated by `MUX_ANTHROPIC_PROMPT_CACHE` (default `true`)

Translator-level fix → every Anthropic-bound client benefits transparently.

## Notes for reviewers

- `toAnthropicInput` and `translateToolsToAnthropic` gained an `opts.cacheControl` parameter rather than reading `config` directly — keeps the translator pure and easy to test. The adapter (`src/providers/anthropic-sdk.ts`) reads the flag once and passes it down.
- Return type of `toAnthropicInput.system` widened from `string | undefined` to `string | AnthropicSystemBlock[] | undefined`. The oauth prefix path in the Anthropic adapter was adjusted to merge cleanly with both shapes.
- `toOpenAIResponse` only emits `prompt_tokens_details` when the response actually carries cache fields — non-Anthropic paths and pre-cache Anthropic responses are unaffected.
- Non-Anthropic downstreams (openai-compatible) are untouched: `cache_control` is only applied inside the Anthropic SDK adapter's prepare path.

## Test plan

- [x] `npm test` — 88/88 passing, including 11 new tests covering cache-on/off for system, tools, and history, plus usage mapping
- [x] `npm run check` — clean
- [ ] Smoke test against a live Anthropic backend: fire two identical requests through a running Mux and confirm `prompt_tokens_details.cached_tokens > 0` on the second response
- [ ] Deploy to prod proxy; confirm `cache_read_input_tokens` dominates within a single `agent-max` session after turn 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)