### PR TITLE
feat: add /v1/responses passthrough MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ DOWNSTREAM_AUTH_MODE=bearer
 DOWNSTREAM_EXTRA_HEADERS={}
 # Request timeout for downstream call (milliseconds)
 DOWNSTREAM_TIMEOUT_MS=30000
+# Comma-separated protocols the legacy/default downstream supports.
+# Set to "chat_completions,responses" to enable native POST /v1/responses
+# routing to this downstream (requires the downstream to expose /responses).
+DOWNSTREAM_PROTOCOLS=chat_completions
 # If true and DOWNSTREAM_BASE_URL is empty, Mux returns the local mock response.
 # Defaults to true outside production, false in production.
 DOWNSTREAM_MOCK_FALLBACK=true

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Mux is the control point for that problem.
 ## What Mux provides
 
 - an OpenAI-compatible `/v1/chat/completions` endpoint
+- native `POST /v1/responses` passthrough for responses-capable downstreams
 - a configurable policy-based routing rules
 - support for routing across models and providers
 - fallback and escalation handling
@@ -72,7 +73,7 @@ ANTHROPIC_BASE_URL=https://api.anthropic.com        # or your proxy URL
 DOWNSTREAM_TIMEOUT_MS=30000
 ```
 
-> **Note:** Keep sending OpenAI-compatible requests to Mux (`/v1/chat/completions`). Mux translates to the downstream API internally.
+> **Note:** `anthropic-sdk` mode still accepts OpenAI-compatible chat requests only. Native `/v1/responses` is currently supported for `openai-compatible` downstreams that expose a real Responses API.
 
 ## Routing behavior
 
@@ -89,13 +90,28 @@ Routing for Max runtime requests is evaluated on the **last user message only** 
 
 Route decisions are logged with: `runtime`, `requestedModel`, `resolvedModel`, `routeReason`, `provider`, `backendTarget`.
 
-## Example request
+### Enable native Responses routing
+
+If you want Mux to accept `POST /v1/responses` for a legacy/default `openai-compatible` downstream, set:
+
+```bash
+DOWNSTREAM_PROTOCOLS=chat_completions,responses
+```
+
+Providers configured via `PROVIDERS` can also declare `protocols: ["chat_completions", "responses"]`.
+
+## Example requests
 
 ```bash
 curl -s http://localhost:8787/v1/chat/completions \
   -H 'content-type: application/json' \
   -H 'x-runtime: openclaw' \
   -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "say hi"}]}' | jq
+
+curl -s http://localhost:8787/v1/responses \
+  -H 'content-type: application/json' \
+  -H 'x-runtime: openclaw' \
+  -d '{"model": "gpt-4o", "input": [{"role": "user", "content": [{"type": "input_text", "text": "say hi"}]}]}' | jq
 ```
 
 ## Environment variables
@@ -112,6 +128,7 @@ curl -s http://localhost:8787/v1/chat/completions \
 | `DOWNSTREAM_AUTH_MODE` | `bearer` | `bearer` \| `x-api-key` \| `passthrough` \| `none` |
 | `DOWNSTREAM_EXTRA_HEADERS` | `{}` | JSON map of extra static headers |
 | `DOWNSTREAM_TIMEOUT_MS` | `30000` | Request timeout in ms |
+| `DOWNSTREAM_PROTOCOLS` | `chat_completions` | Comma-separated legacy/default downstream protocols (`chat_completions`, `responses`) |
 | `DOWNSTREAM_MOCK_FALLBACK` | `true` (dev) | Return mock response when no backend configured |
 | `ANTHROPIC_OAUTH_TOKEN` | — | OAuth token (preferred for anthropic-sdk) |
 | `ANTHROPIC_API_KEY` | — | API key fallback for anthropic-sdk |

--- a/docs/deploy-debian.md
+++ b/docs/deploy-debian.md
@@ -1,0 +1,237 @@
+# Deploying Mux on Debian (NAS / homelab)
+
+This guide installs Mux as a long-running systemd service on a Debian-based
+machine (tested on Debian 12 / Ubuntu 22.04+). Mux is a stateless Node
+process — no database, no persistent disk requirements beyond the source
+checkout and `node_modules`.
+
+## Prerequisites
+
+- Debian 12+ (or Ubuntu 22.04+) with `systemd`
+- Node.js **22.x** (matches the CI version pinned in `.github/workflows/ci.yml`)
+- A dedicated UNIX user (`mux`), to avoid running as root
+- Outbound HTTPS to whichever downstream(s) you'll route to (OpenAI,
+  Anthropic, a local LiteLLM proxy, etc.)
+
+Install Node 22 via NodeSource:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs git
+```
+
+## Layout
+
+```
+/opt/mux/                      # source checkout (git)
+/opt/mux/.env                  # environment file (chmod 600, owner mux:mux)
+/etc/systemd/system/mux.service
+```
+
+## Install
+
+```bash
+sudo useradd --system --create-home --home-dir /var/lib/mux --shell /usr/sbin/nologin mux
+sudo mkdir -p /opt/mux
+sudo chown mux:mux /opt/mux
+
+sudo -u mux git clone https://github.com/arniesaha/mux.git /opt/mux
+cd /opt/mux
+sudo -u mux npm ci
+sudo -u mux npm run build
+```
+
+## Configure
+
+Copy `.env.example` to `/opt/mux/.env` and edit. The minimum required keys
+for a typical NAS deployment:
+
+```bash
+sudo -u mux cp /opt/mux/.env.example /opt/mux/.env
+sudo chmod 600 /opt/mux/.env
+sudo chown mux:mux /opt/mux/.env
+```
+
+Edit `/opt/mux/.env`:
+
+```ini
+PORT=8787
+NODE_ENV=production
+
+# Pick ONE downstream mode. For OpenClaw + LiteLLM in front of OpenAI/Codex:
+DOWNSTREAM_MODE=openai-compatible
+DOWNSTREAM_BASE_URL=http://localhost:4000/v1   # LiteLLM, vLLM, etc.
+DOWNSTREAM_AUTH_MODE=bearer
+DOWNSTREAM_API_KEY=<key for the downstream>
+
+# Enable native /v1/responses passthrough alongside chat completions.
+# Without this, Mux returns 503 "provider does not support responses protocol".
+DOWNSTREAM_PROTOCOLS=chat_completions,responses
+
+# Mock fallback OFF in prod — without a configured downstream, Mux returns 503
+DOWNSTREAM_MOCK_FALLBACK=false
+
+# Optional: AgentWeave OTLP for tracing/cost dashboards
+AGENTWEAVE_OTLP_ENDPOINT=http://localhost:30400
+AGENTWEAVE_AGENT_ID=mux-router
+```
+
+Adjust `MODEL_MAP` / `ANTHROPIC_MODEL_MAP` / `PROVIDERS` as needed. See
+`.env.example` for the full surface.
+
+## systemd unit
+
+Create `/etc/systemd/system/mux.service`:
+
+```ini
+[Unit]
+Description=Mux model router
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=mux
+Group=mux
+WorkingDirectory=/opt/mux
+EnvironmentFile=/opt/mux/.env
+ExecStart=/usr/bin/node dist/server.js
+Restart=on-failure
+RestartSec=2
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/mux
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now mux.service
+sudo systemctl status mux.service
+journalctl -u mux.service -f
+```
+
+Verify:
+
+```bash
+curl -s http://localhost:8787/health
+# {"ok":true,"service":"mux","env":"production"}
+```
+
+## Upgrades
+
+```bash
+sudo -u mux git -C /opt/mux fetch --tags origin
+sudo -u mux git -C /opt/mux merge --ff-only origin/master
+sudo -u mux npm ci --prefix /opt/mux
+sudo -u mux npm run build --prefix /opt/mux
+sudo systemctl restart mux.service
+```
+
+If `npm ci` fails or you need to roll back: `git -C /opt/mux reset --hard <prev-sha>`
+followed by rebuild + restart.
+
+## Reverse proxy / TLS (optional)
+
+For LAN-only access, exposing port 8787 directly is fine. For remote access,
+front Mux with nginx or Caddy:
+
+```caddy
+mux.local {
+  reverse_proxy localhost:8787 {
+    flush_interval -1   # critical for SSE streaming
+  }
+}
+```
+
+The `flush_interval -1` (or `proxy_buffering off` in nginx) is **required**
+for `stream: true` responses — without it the proxy will buffer SSE chunks
+and clients will see no events until the response completes.
+
+## Plumbing with OpenClaw + AgentWeave
+
+Mux sits between agent runtimes and the actual LLM endpoints. Typical chain
+for a NAS deployment:
+
+```
+OpenClaw agent ─► AgentWeave proxy ─► Mux ─► LiteLLM/Anthropic/OpenAI
+```
+
+### OpenClaw → Mux
+
+Configure your OpenClaw `openai-codex` (or any OpenAI-compatible) provider
+with a custom `baseUrl` pointing at Mux:
+
+```jsonc
+{
+  "id": "mux-openai",
+  "kind": "openai-codex",
+  "baseUrl": "http://<nas-host>:8787/v1",
+  "auth": { "mode": "bearer", "token": "<downstream key>" }
+}
+```
+
+OpenClaw's `openai-codex` provider posts to `<baseUrl>/responses` and
+`<baseUrl>/chat/completions`. With `baseUrl=http://nas:8787/v1`, those land
+on Mux's `POST /v1/responses` and `POST /v1/chat/completions`.
+
+> **Note:** OpenClaw fix `13085b0bdf` ("honor providerConfig.baseUrl in
+> dynamic-model synthesis fallback") is required — earlier versions silently
+> fall back to `api.openai.com` / `chatgpt.com`, bypassing Mux. Make sure
+> the OpenClaw build is at or after that commit.
+
+### AgentWeave → Mux
+
+If you're routing through AgentWeave's Python proxy first, point its
+upstream at Mux. AgentWeave forwards `Authorization` and `X-AgentWeave-*`
+headers verbatim; Mux uses `DOWNSTREAM_AUTH_MODE=passthrough` to forward
+the inbound `Authorization` to the eventual downstream:
+
+```ini
+DOWNSTREAM_AUTH_MODE=passthrough
+```
+
+> **Note:** AgentWeave PR #183 reroutes `/v1/responses` calls carrying
+> ChatGPT-mode JWTs (`eyJ...`) to `codex/responses`. That rewrite happens
+> inside AgentWeave's proxy and is independent of Mux. If AgentWeave
+> forwards the call to Mux as `/v1/responses`, Mux handles it normally; if
+> the rewrite redirects to `chatgpt.com` directly, the call doesn't transit
+> Mux at all.
+
+### Caller agent attribution
+
+Mux propagates `X-AgentWeave-*` headers to the downstream and emits
+`prov.agent.id` span attributes when `X-AgentWeave-Agent-Id` is present.
+No additional config required — just make sure your reverse proxy doesn't
+strip those headers.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `503 service_unavailable: provider 'default' does not support responses protocol` | `DOWNSTREAM_PROTOCOLS` not set to include `responses` |
+| `502 downstream_error` with `additional_properties_strict` complaint | A pre-PR-54 Mux is leaking the `runtime` field downstream — upgrade past PR #54 |
+| SSE stream stalls / events arrive in one chunk at the end | Reverse proxy buffering — set `flush_interval -1` (Caddy) / `proxy_buffering off` (nginx) |
+| 401 from upstream when using ChatGPT-mode JWT | Wrong upstream — ChatGPT-mode tokens require `chatgpt.com/backend-api/codex`, not `api.openai.com`. See AgentWeave #183. |
+
+## Environment reference
+
+Full env-var reference lives in `.env.example` and the README's
+"Environment variables" table. The keys most relevant to a NAS deploy:
+
+- `PORT`, `NODE_ENV`
+- `DOWNSTREAM_MODE`, `DOWNSTREAM_BASE_URL`, `DOWNSTREAM_AUTH_MODE`, `DOWNSTREAM_API_KEY`
+- `DOWNSTREAM_PROTOCOLS` *(new in PR #54 — needed for /v1/responses)*
+- `DOWNSTREAM_MOCK_FALLBACK=false` for production
+- `AGENTWEAVE_OTLP_ENDPOINT`, `AGENTWEAVE_AGENT_ID`
+- `ANTHROPIC_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` if `DOWNSTREAM_MODE=anthropic-sdk`

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,22 +4,184 @@ import pino from "pino";
 import { config } from "./config.js";
 import {
   callDownstream,
+  callResponsesDownstream,
   DownstreamNotConfiguredError,
   DownstreamRequestError,
   streamDownstream,
+  streamResponsesDownstream,
   type DownstreamRequestContext,
 } from "./downstream.js";
 import { resolveRoute } from "./policy.js";
-// Import the providers barrel for its side-effects — each adapter registers
-// itself with the registry on module load. Must happen before resolveRoute or
-// callDownstream runs.
 import "./providers/index.js";
 import { withTracedRequest, setSpanAttrs } from "./tracing.js";
-import type { ChatCompletionsRequest } from "./types.js";
+import type {
+  ChatCompletionsRequest,
+  ChatMessage,
+  RequestProtocol,
+  ResponsesInputItem,
+  ResponsesRequest,
+} from "./types.js";
 
 const logger = pino({
   level: config.nodeEnv === "development" ? "debug" : "info",
 });
+
+const extractRuntime = (body: { runtime?: string }, req: express.Request): string => {
+  return body.runtime || req.header("x-runtime") || "unknown";
+};
+
+const extractAgentweaveHeaders = (req: express.Request): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === "string" && key.startsWith("x-agentweave-")) {
+      headers[key] = value;
+    }
+  }
+  return headers;
+};
+
+const buildDownstreamContext = (req: express.Request): DownstreamRequestContext => ({
+  incomingAuthorizationHeader: req.header("authorization") ?? undefined,
+  agentweaveHeaders: extractAgentweaveHeaders(req),
+});
+
+const extractTextFromUnknown = (value: unknown): string[] => {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(extractTextFromUnknown);
+  if (!value || typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+  const out: string[] = [];
+  if (typeof record.text === "string") out.push(record.text);
+  if (typeof record.content === "string") out.push(record.content);
+  if (Array.isArray(record.content)) out.push(...record.content.flatMap(extractTextFromUnknown));
+  if (record.input != null) out.push(...extractTextFromUnknown(record.input));
+  return out;
+};
+
+const buildPromptPreviewForChat = (messages: ChatMessage[]): string => {
+  const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
+  if (!lastUserMsg) return "";
+  return extractTextFromUnknown(lastUserMsg.content).join(" ").slice(0, 200);
+};
+
+const buildPromptPreviewForResponses = (input: ResponsesRequest["input"]): string => {
+  if (input == null) return "";
+  const items = Array.isArray(input) ? input : [input];
+  return items.flatMap((item) => extractTextFromUnknown(item)).join(" ").slice(0, 200);
+};
+
+const normalizeResponsesInputToMessages = (input: ResponsesRequest["input"]): ChatMessage[] => {
+  if (input == null) return [{ role: "user", content: "" }];
+  const items = Array.isArray(input) ? input : [input];
+  const content = items
+    .map((item) => {
+      if (typeof item === "string") return item;
+      const record = item as Record<string, unknown>;
+      if (typeof record.role === "string" && typeof record.content === "string") {
+        return record.content;
+      }
+      return extractTextFromUnknown(item).join(" ");
+    })
+    .filter(Boolean)
+    .join("\n");
+  return [{ role: "user", content }];
+};
+
+const logRouteDecision = (params: {
+  protocol: RequestProtocol;
+  runtime: string;
+  route: ReturnType<typeof resolveRoute>;
+  callerAgentId?: string;
+  promptPreview: string;
+  messageCount?: number;
+  inputItemCount?: number;
+}) => {
+  const { protocol, runtime, route, callerAgentId, promptPreview, messageCount, inputItemCount } = params;
+  setSpanAttrs({
+    "prov.route.protocol": protocol,
+    "prov.route.requested_model": route.requestedModel,
+    "prov.route.resolved_model": route.resolvedModel,
+    "prov.route.reason": route.routeReason,
+    "prov.route.runtime": runtime,
+    "prov.route.provider_id": route.providerId,
+    "prov.llm.model": route.resolvedModel,
+    "prov.llm.prompt_preview": promptPreview,
+    ...(typeof messageCount === "number" ? { "prov.route.message_count": messageCount } : {}),
+    ...(typeof inputItemCount === "number" ? { "prov.route.input_item_count": inputItemCount } : {}),
+    ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
+  });
+
+  logger.info({
+    event: "mux.route_decision",
+    protocol,
+    runtime,
+    requestedModel: route.requestedModel,
+    resolvedModel: route.resolvedModel,
+    routeReason: route.routeReason,
+    provider: route.provider,
+    providerId: route.providerId,
+    backendTarget: route.backendTarget,
+    downstreamMode: config.downstreamMode,
+  });
+};
+
+const handleAppError = (
+  error: unknown,
+  runtime: string,
+  res: express.Response,
+  protocol: RequestProtocol,
+): void => {
+  if (error instanceof DownstreamNotConfiguredError) {
+    logger.warn({
+      event: "mux.downstream_not_configured",
+      protocol,
+      runtime,
+      message: error.message,
+    });
+
+    res.status(503).json({
+      error: {
+        type: "service_unavailable",
+        message: error.message,
+      },
+    });
+    return;
+  }
+
+  if (error instanceof DownstreamRequestError) {
+    logger.error({
+      event: "mux.downstream_error",
+      protocol,
+      runtime,
+      status: error.status,
+      payload: error.payload,
+    });
+
+    res.status(502).json({
+      error: {
+        type: "downstream_error",
+        message: "Downstream request failed",
+        status: error.status,
+        details: error.payload,
+      },
+    });
+    return;
+  }
+
+  logger.error({
+    event: "mux.unhandled_error",
+    protocol,
+    runtime,
+    err: error,
+  });
+
+  res.status(500).json({
+    error: {
+      type: "internal_error",
+      message: "Unexpected server error",
+    },
+  });
+};
 
 export const createApp = () => {
   const app = express();
@@ -42,114 +204,82 @@ export const createApp = () => {
     }
 
     await withTracedRequest("mux", async () => {
-      const runtime = body.runtime || req.header("x-runtime") || "unknown";
+      const runtime = extractRuntime(body, req);
       const routedBody: ChatCompletionsRequest = { ...body, runtime };
-      const route = resolveRoute(routedBody);
-      const callerAgentId = req.header("x-agentweave-agent-id");
+      const route = resolveRoute({ ...routedBody, protocol: "chat_completions" } as ChatCompletionsRequest & { protocol: RequestProtocol });
+      const callerAgentId = req.header("x-agentweave-agent-id") ?? undefined;
+      const promptPreview = buildPromptPreviewForChat(body.messages);
 
-      // Extract a short prompt preview from the last user message for tracing
-      const lastUserMsg = [...body.messages].reverse().find(m => m.role === "user");
-      const promptPreview = typeof lastUserMsg?.content === "string"
-        ? lastUserMsg.content.slice(0, 200)
-        : Array.isArray(lastUserMsg?.content)
-          ? (lastUserMsg.content.find((b: any) => b.type === "text") as any)?.text?.slice(0, 200) ?? ""
-          : "";
-
-      setSpanAttrs({
-        "prov.route.requested_model": route.requestedModel,
-        "prov.route.resolved_model": route.resolvedModel,
-        "prov.route.reason": route.routeReason,
-        "prov.route.runtime": runtime,
-        "prov.route.provider_id": route.providerId,
-        "prov.llm.model": route.resolvedModel,
-        "prov.llm.prompt_preview": promptPreview,
-        "prov.route.message_count": body.messages.length,
-        ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
-      });
-
-      logger.info({
-        event: "mux.route_decision",
+      logRouteDecision({
+        protocol: "chat_completions",
         runtime,
-        requestedModel: route.requestedModel,
-        resolvedModel: route.resolvedModel,
-        routeReason: route.routeReason,
-        provider: route.provider,
-        providerId: route.providerId,
-        backendTarget: route.backendTarget,
-        downstreamMode: config.downstreamMode,
+        route,
+        callerAgentId,
+        promptPreview,
+        messageCount: body.messages.length,
       });
 
       try {
-        // Forward any X-AgentWeave-* headers from the caller so the proxy
-        // can attribute the call to the original agent/session.
-        const agentweaveHeaders: Record<string, string> = {};
-        for (const [key, value] of Object.entries(req.headers)) {
-          if (typeof value === "string" && key.startsWith("x-agentweave-")) {
-            agentweaveHeaders[key] = value;
-          }
-        }
-
-        const downstreamContext: DownstreamRequestContext = {
-          incomingAuthorizationHeader: req.header("authorization") ?? undefined,
-          agentweaveHeaders,
-        };
-
+        const downstreamContext = buildDownstreamContext(req);
         if (routedBody.stream) {
           await streamDownstream(routedBody, route, res, downstreamContext);
           return;
         }
 
         const downstream = await callDownstream(routedBody, route, downstreamContext);
-
         res.status(200).json(downstream);
       } catch (error) {
-        if (error instanceof DownstreamNotConfiguredError) {
-          logger.warn({
-            event: "mux.downstream_not_configured",
-            runtime,
-            message: error.message,
-          });
+        handleAppError(error, runtime, res, "chat_completions");
+      }
+    });
+  });
 
-          res.status(503).json({
-            error: {
-              type: "service_unavailable",
-              message: error.message,
-            },
-          });
+  app.post("/v1/responses", async (req, res) => {
+    const body = req.body as ResponsesRequest;
+
+    if (!body?.model) {
+      return res.status(400).json({
+        error: {
+          message: "Invalid payload: model is required",
+          type: "invalid_request_error",
+        },
+      });
+    }
+
+    await withTracedRequest("mux", async () => {
+      const runtime = extractRuntime(body, req);
+      const routedBody: ResponsesRequest = { ...body, runtime };
+      const routingRequest: ChatCompletionsRequest = {
+        model: body.model,
+        messages: normalizeResponsesInputToMessages(body.input),
+        stream: body.stream,
+        runtime,
+      };
+      const route = resolveRoute({ ...routingRequest, protocol: "responses" } as ChatCompletionsRequest & { protocol: RequestProtocol });
+      const callerAgentId = req.header("x-agentweave-agent-id") ?? undefined;
+      const inputItems = body.input == null ? 0 : Array.isArray(body.input) ? body.input.length : 1;
+      const promptPreview = buildPromptPreviewForResponses(body.input);
+
+      logRouteDecision({
+        protocol: "responses",
+        runtime,
+        route,
+        callerAgentId,
+        promptPreview,
+        inputItemCount: inputItems,
+      });
+
+      try {
+        const downstreamContext = buildDownstreamContext(req);
+        if (routedBody.stream) {
+          await streamResponsesDownstream(routedBody, route, res, downstreamContext);
           return;
         }
 
-        if (error instanceof DownstreamRequestError) {
-          logger.error({
-            event: "mux.downstream_error",
-            runtime,
-            status: error.status,
-            payload: error.payload,
-          });
-
-          res.status(502).json({
-            error: {
-              type: "downstream_error",
-              message: "Downstream request failed",
-              status: error.status,
-              details: error.payload,
-            },
-          });
-          return;
-        }
-
-        logger.error({
-          event: "mux.unhandled_error",
-          runtime,
-          err: error,
-        });
-
-        res.status(500).json({
-          error: {
-            type: "internal_error",
-            message: "Unexpected server error",
-          },
-        });
+        const downstream = await callResponsesDownstream(routedBody, route, downstreamContext);
+        res.status(200).json(downstream);
+      } catch (error) {
+        handleAppError(error, runtime, res, "responses");
       }
     });
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,6 @@ import type {
   ChatCompletionsRequest,
   ChatMessage,
   RequestProtocol,
-  ResponsesInputItem,
   ResponsesRequest,
 } from "./types.js";
 
@@ -205,8 +204,8 @@ export const createApp = () => {
 
     await withTracedRequest("mux", async () => {
       const runtime = extractRuntime(body, req);
-      const routedBody: ChatCompletionsRequest = { ...body, runtime };
-      const route = resolveRoute({ ...routedBody, protocol: "chat_completions" } as ChatCompletionsRequest & { protocol: RequestProtocol });
+      const routedBody: ChatCompletionsRequest = { ...body, runtime, protocol: "chat_completions" };
+      const route = resolveRoute(routedBody);
       const callerAgentId = req.header("x-agentweave-agent-id") ?? undefined;
       const promptPreview = buildPromptPreviewForChat(body.messages);
 
@@ -249,13 +248,17 @@ export const createApp = () => {
     await withTracedRequest("mux", async () => {
       const runtime = extractRuntime(body, req);
       const routedBody: ResponsesRequest = { ...body, runtime };
+      // Synthetic ChatCompletionsRequest used only for routing/policy
+      // decisions. Not forwarded downstream — the responses adapter sends
+      // `routedBody` (the original ResponsesRequest) verbatim.
       const routingRequest: ChatCompletionsRequest = {
         model: body.model,
         messages: normalizeResponsesInputToMessages(body.input),
         stream: body.stream,
         runtime,
+        protocol: "responses",
       };
-      const route = resolveRoute({ ...routingRequest, protocol: "responses" } as ChatCompletionsRequest & { protocol: RequestProtocol });
+      const route = resolveRoute(routingRequest);
       const callerAgentId = req.header("x-agentweave-agent-id") ?? undefined;
       const inputItems = body.input == null ? 0 : Array.isArray(body.input) ? body.input.length : 1;
       const promptPreview = buildPromptPreviewForResponses(body.input);

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,9 +53,18 @@ const parseDownstreamMode = (input: string | undefined): DownstreamMode => {
 };
 
 
+const isRequestProtocol = (v: unknown): v is RequestProtocol =>
+  v === "chat_completions" || v === "responses";
+
 const parseProtocols = (input: unknown, defaultValue: RequestProtocol[]): RequestProtocol[] => {
   if (!Array.isArray(input)) return defaultValue;
-  const out = input.filter((v): v is RequestProtocol => v === "chat_completions" || v === "responses");
+  const out = input.filter(isRequestProtocol);
+  return out.length > 0 ? out : defaultValue;
+};
+
+const parseProtocolsCsv = (input: string | undefined, defaultValue: RequestProtocol[]): RequestProtocol[] => {
+  if (!input?.trim()) return defaultValue;
+  const out = input.split(",").map((s) => s.trim()).filter(isRequestProtocol);
   return out.length > 0 ? out : defaultValue;
 };
 
@@ -143,6 +152,7 @@ export const config = {
   anthropicOauthToken: process.env.ANTHROPIC_OAUTH_TOKEN,
   downstreamTimeoutMs: parseNumber(process.env.DOWNSTREAM_TIMEOUT_MS, 30_000),
   downstreamExtraHeaders: parseJsonMap(process.env.DOWNSTREAM_EXTRA_HEADERS),
+  downstreamProtocols: parseProtocolsCsv(process.env.DOWNSTREAM_PROTOCOLS, ["chat_completions"]),
   downstreamMockFallbackEnabled: parseBoolean(
     process.env.DOWNSTREAM_MOCK_FALLBACK,
     process.env.NODE_ENV !== "production",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 
 import type { ProviderConfig, ProviderKind } from "./providers/types.js";
+import type { RequestProtocol } from "./types.js";
 
 dotenv.config();
 
@@ -51,6 +52,13 @@ const parseDownstreamMode = (input: string | undefined): DownstreamMode => {
   return "openai-compatible";
 };
 
+
+const parseProtocols = (input: unknown, defaultValue: RequestProtocol[]): RequestProtocol[] => {
+  if (!Array.isArray(input)) return defaultValue;
+  const out = input.filter((v): v is RequestProtocol => v === "chat_completions" || v === "responses");
+  return out.length > 0 ? out : defaultValue;
+};
+
 const parseProviders = (input: string | undefined): ProviderConfig[] => {
   if (!input?.trim()) return [];
   try {
@@ -81,6 +89,7 @@ const parseProviders = (input: string | undefined): ProviderConfig[] => {
       out.push({
         id: r.id,
         kind,
+        protocols: parseProtocols(r.protocols, ["chat_completions"]),
         baseUrl:
           typeof r.baseUrl === "string" ? normalizeBaseUrl(r.baseUrl) : null,
         auth,

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -723,6 +723,10 @@ type ToolCallAccum = {
 export type StreamResult = {
   inputTokens: number;
   outputTokens: number;
+  // Ephemeral-cache token buckets Anthropic reports alongside input_tokens.
+  // Both default to 0 when the model/request doesn't carry cache fields.
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
   stopReason: string | null;
 };
 
@@ -768,6 +772,8 @@ export const streamAnthropicToOpenAI = async (
   let finalStopReason: string | null = null;
   let inputTokens = 0;
   let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheCreationTokens = 0;
   let phase: string = "start";
   let aborted = false;
   let clientClosed = false;
@@ -798,10 +804,29 @@ export const streamAnthropicToOpenAI = async (
       phase = event.type;
       switch (event.type) {
         case "message_start": {
-          // role chunk already emitted; capture input token count from usage
-          const msg = (event as { message?: { usage?: { input_tokens?: number } } }).message;
-          if (msg?.usage && typeof msg.usage.input_tokens === "number") {
-            inputTokens = msg.usage.input_tokens;
+          // role chunk already emitted; capture usage counters. Anthropic
+          // splits billable input into input_tokens (fresh) plus two cache
+          // buckets — we track all three so the final usage chunk can roll
+          // them together for OpenAI parity (see #52).
+          const msg = (event as {
+            message?: {
+              usage?: {
+                input_tokens?: number;
+                cache_read_input_tokens?: number;
+                cache_creation_input_tokens?: number;
+              };
+            };
+          }).message;
+          if (msg?.usage) {
+            if (typeof msg.usage.input_tokens === "number") {
+              inputTokens = msg.usage.input_tokens;
+            }
+            if (typeof msg.usage.cache_read_input_tokens === "number") {
+              cacheReadTokens = msg.usage.cache_read_input_tokens;
+            }
+            if (typeof msg.usage.cache_creation_input_tokens === "number") {
+              cacheCreationTokens = msg.usage.cache_creation_input_tokens;
+            }
           }
           break;
         }
@@ -863,10 +888,26 @@ export const streamAnthropicToOpenAI = async (
           if (d && typeof d.stop_reason === "string") {
             finalStopReason = d.stop_reason;
           }
-          // Anthropic output_tokens is cumulative — always take the latest value
-          const mdUsage = (event as { usage?: { output_tokens?: number } }).usage;
-          if (mdUsage && typeof mdUsage.output_tokens === "number") {
-            outputTokens = mdUsage.output_tokens;
+          // Anthropic output_tokens is cumulative — always take the latest value.
+          // Some models also update cache_* buckets here; apply the same
+          // last-value-wins rule so telemetry matches what Anthropic billed.
+          const mdUsage = (event as {
+            usage?: {
+              output_tokens?: number;
+              cache_read_input_tokens?: number;
+              cache_creation_input_tokens?: number;
+            };
+          }).usage;
+          if (mdUsage) {
+            if (typeof mdUsage.output_tokens === "number") {
+              outputTokens = mdUsage.output_tokens;
+            }
+            if (typeof mdUsage.cache_read_input_tokens === "number") {
+              cacheReadTokens = mdUsage.cache_read_input_tokens;
+            }
+            if (typeof mdUsage.cache_creation_input_tokens === "number") {
+              cacheCreationTokens = mdUsage.cache_creation_input_tokens;
+            }
           }
           break;
         }
@@ -887,6 +928,8 @@ export const streamAnthropicToOpenAI = async (
       stopSequence: null,
       inputTokens,
       outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
       blockCount: (textLength > 0 ? 1 : 0) + toolUseBlockCount,
       blockTypes: [
         ...(textLength > 0 ? ["text"] : []),
@@ -907,6 +950,33 @@ export const streamAnthropicToOpenAI = async (
 
     if (!clientClosed) {
       writeChunk({}, anthropicStopReasonToOpenAI(finalStopReason));
+      // OpenAI include_usage convention: trailing chunk with choices: [] + usage.
+      // Mirrors toOpenAIResponse — cache tokens get rolled into prompt_tokens
+      // so billable prompt size is symmetric across streaming and non-streaming.
+      const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
+      const usage: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+        prompt_tokens_details?: { cached_tokens: number };
+      } = {
+        prompt_tokens: promptTokens,
+        completion_tokens: outputTokens,
+        total_tokens: promptTokens + outputTokens,
+      };
+      if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
+        usage.prompt_tokens_details = { cached_tokens: cacheReadTokens };
+      }
+      res.write(
+        `data: ${JSON.stringify({
+          id: streamId,
+          object: "chat.completion.chunk",
+          created,
+          model,
+          choices: [],
+          usage,
+        })}\n\n`,
+      );
       res.write("data: [DONE]\n\n");
       res.end();
     }
@@ -928,7 +998,13 @@ export const streamAnthropicToOpenAI = async (
     res.off("close", onClose);
   }
 
-  return { inputTokens, outputTokens, stopReason: finalStopReason };
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    stopReason: finalStopReason,
+  };
 };
 
 export const emitDownstreamResponseAsSse = (res: express.Response, completion: DownstreamResponse): void => {

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -15,6 +15,7 @@ import { setSpanAttrs } from "./tracing.js";
 import "./providers/index.js";
 import type {
   ChatCompletionsRequest,
+  ResponsesRequest,
   OpenAIToolCall,
   OpenAIToolChoice,
   OpenAIToolDef,
@@ -25,6 +26,9 @@ export const downstreamLogger = pino({
   level: config.nodeEnv === "development" ? "debug" : "info",
   name: "mux.downstream",
 });
+
+
+export type DownstreamResponsesResponse = Record<string, unknown>;
 
 export type DownstreamResponse = {
   id: string;
@@ -51,6 +55,56 @@ export type DownstreamResponse = {
       cached_tokens: number;
     };
   };
+};
+
+
+export const buildMockResponsesResponse = (
+  req: ResponsesRequest,
+  route: RouteDecision,
+): DownstreamResponsesResponse => ({
+  id: `resp_${Date.now()}` ,
+  object: "response",
+  created_at: Math.floor(Date.now() / 1000),
+  model: route.resolvedModel,
+  output: [
+    {
+      type: "message",
+      id: `msg_${Date.now()}`,
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: `MVP stub response from Mux responses path. requested=${route.requestedModel}, resolved=${route.resolvedModel}, reason=${route.routeReason}`,
+          annotations: [],
+        },
+      ],
+    },
+  ],
+  text: `MVP stub response from Mux responses path. requested=${route.requestedModel}, resolved=${route.resolvedModel}, reason=${route.routeReason}`,
+  usage: {
+    input_tokens: Math.max(1, Math.ceil(JSON.stringify(req.input ?? "").length / 4)),
+    output_tokens: 24,
+    total_tokens: Math.max(25, Math.ceil(JSON.stringify(req.input ?? "").length / 4) + 24),
+  },
+});
+
+export const emitDownstreamResponsesAsSse = (
+  res: express.Response,
+  response: DownstreamResponsesResponse,
+): void => {
+  if (!res.headersSent) {
+    res.status(200);
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+  }
+  const id = String(response.id ?? `resp_${Date.now()}`);
+  const model = String(response.model ?? "unknown");
+  const text = String((response as any).text ?? "");
+  res.write(`event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id, model } })}\n\n`);
+  res.write(`event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", item_id: `${id}_item`, delta: text })}\n\n`);
+  res.write(`event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response })}\n\n`);
+  res.end();
 };
 
 // Anthropic ephemeral prompt-cache breakpoint. Attaching this to a content
@@ -1086,4 +1140,97 @@ export const streamDownstream = async (
     }
   }
   throw lastError ?? new DownstreamNotConfiguredError("no providers available");
+};
+
+
+export const callResponsesDownstream = async (
+  req: ResponsesRequest,
+  route: RouteDecision,
+  context?: DownstreamRequestContext,
+): Promise<DownstreamResponsesResponse> => {
+  const chain = buildProviderChain(route);
+  const failedProviders: string[] = [];
+  let lastError: unknown;
+
+  for (let i = 0; i < chain.length; i++) {
+    const providerId = chain[i]!;
+    const provider = getProvider(providerId);
+    if (!provider || !provider.protocols.includes("responses") || !provider.callResponses) {
+      if (
+        i === 0 &&
+        chain.length === 1 &&
+        providerId === "default" &&
+        config.downstreamMockFallbackEnabled
+      ) {
+        return buildMockResponsesResponse(req, route);
+      }
+      lastError = new DownstreamNotConfiguredError(
+        `provider '${providerId}' does not support responses protocol`,
+      );
+      failedProviders.push(providerId);
+      if (i === chain.length - 1) throw lastError;
+      continue;
+    }
+
+    if (i > 0) annotateFailoverHop(i, providerId, failedProviders, lastError);
+
+    try {
+      return await provider.callResponses(req, route, context) as DownstreamResponsesResponse;
+    } catch (err) {
+      lastError = err;
+      failedProviders.push(providerId);
+      if (!isRetryableDownstreamError(err)) throw err;
+      if (i === chain.length - 1) throw err;
+    }
+  }
+
+  throw lastError ?? new DownstreamNotConfiguredError("no responses-capable providers available");
+};
+
+export const streamResponsesDownstream = async (
+  req: ResponsesRequest,
+  route: RouteDecision,
+  res: express.Response,
+  context?: DownstreamRequestContext,
+): Promise<void> => {
+  const chain = buildProviderChain(route);
+  const failedProviders: string[] = [];
+  let lastError: unknown;
+
+  for (let i = 0; i < chain.length; i++) {
+    const providerId = chain[i]!;
+    const provider = getProvider(providerId);
+    if (!provider || !provider.protocols.includes("responses") || !provider.streamResponses) {
+      if (
+        i === 0 &&
+        chain.length === 1 &&
+        providerId === "default" &&
+        config.downstreamMockFallbackEnabled
+      ) {
+        emitDownstreamResponsesAsSse(res, buildMockResponsesResponse(req, route));
+        return;
+      }
+      lastError = new DownstreamNotConfiguredError(
+        `provider '${providerId}' does not support responses protocol`,
+      );
+      failedProviders.push(providerId);
+      if (i === chain.length - 1) throw lastError;
+      continue;
+    }
+
+    if (i > 0) annotateFailoverHop(i, providerId, failedProviders, lastError);
+
+    try {
+      await provider.streamResponses(req, route, res, context);
+      return;
+    } catch (err) {
+      lastError = err;
+      failedProviders.push(providerId);
+      if (res.headersSent) throw err;
+      if (!isRetryableDownstreamError(err)) throw err;
+      if (i === chain.length - 1) throw err;
+    }
+  }
+
+  throw lastError ?? new DownstreamNotConfiguredError("no responses-capable providers available");
 };

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -88,7 +88,12 @@ export const buildMockResponsesResponse = (
   },
 });
 
-export const emitDownstreamResponsesAsSse = (
+// Emits a non-streaming Responses payload as a minimal SSE sequence. Used by
+// the mock fallback path only — real upstreams stream their own SSE which we
+// proxy verbatim. Reads text from the canonical `output[0].content[0].text`
+// shape; the mock builder also sets a top-level `text` mirror so this works
+// without a synthetic walk for the stub case.
+export const emitMockResponsesAsSse = (
   res: express.Response,
   response: DownstreamResponsesResponse,
 ): void => {
@@ -100,11 +105,29 @@ export const emitDownstreamResponsesAsSse = (
   }
   const id = String(response.id ?? `resp_${Date.now()}`);
   const model = String(response.model ?? "unknown");
-  const text = String((response as any).text ?? "");
+  const text = extractMockResponsesText(response);
   res.write(`event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id, model } })}\n\n`);
   res.write(`event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", item_id: `${id}_item`, delta: text })}\n\n`);
   res.write(`event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response })}\n\n`);
   res.end();
+};
+
+const extractMockResponsesText = (response: DownstreamResponsesResponse): string => {
+  const topLevel = (response as { text?: unknown }).text;
+  if (typeof topLevel === "string") return topLevel;
+  const output = (response as { output?: unknown }).output;
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      const content = (item as { content?: unknown })?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          const t = (block as { text?: unknown })?.text;
+          if (typeof t === "string") return t;
+        }
+      }
+    }
+  }
+  return "";
 };
 
 // Anthropic ephemeral prompt-cache breakpoint. Attaching this to a content
@@ -1207,7 +1230,7 @@ export const streamResponsesDownstream = async (
         providerId === "default" &&
         config.downstreamMockFallbackEnabled
       ) {
-        emitDownstreamResponsesAsSse(res, buildMockResponsesResponse(req, route));
+        emitMockResponsesAsSse(res, buildMockResponsesResponse(req, route));
         return;
       }
       lastError = new DownstreamNotConfiguredError(

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,7 +1,7 @@
 import { config } from "./config.js";
 import { listProviders } from "./providers/registry.js";
 import type { Provider } from "./providers/types.js";
-import type { ChatCompletionsRequest, RequestProtocol, RouteDecision } from "./types.js";
+import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
 
 type ProviderSelection = {
   providerId: string;
@@ -154,7 +154,7 @@ const isSimplePrompt = (req: ChatCompletionsRequest): boolean => {
 };
 
 export const resolveRoute = (
-  req: ChatCompletionsRequest & { protocol?: RequestProtocol },
+  req: ChatCompletionsRequest,
   providers?: Provider[],
 ): RouteDecision => {
   const requestedModel = req.model;

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,7 +1,7 @@
 import { config } from "./config.js";
 import { listProviders } from "./providers/registry.js";
 import type { Provider } from "./providers/types.js";
-import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
+import type { ChatCompletionsRequest, RequestProtocol, RouteDecision } from "./types.js";
 
 type ProviderSelection = {
   providerId: string;
@@ -15,9 +15,11 @@ type ProviderSelection = {
 const selectProviderForModel = (
   resolvedModel: string,
   providers: Provider[],
+  protocol: "chat_completions" | "responses",
 ): ProviderSelection | null => {
   const candidates = providers.filter((p) =>
-    p.models.some((m) => m.id === resolvedModel),
+    (p.protocols ?? ["chat_completions"]).includes(protocol) &&
+    (p.models.length === 0 || p.models.some((m) => m.id === resolvedModel)),
   );
   if (candidates.length === 0) return null;
 
@@ -46,7 +48,7 @@ const applyProviderSelection = (
   providers?: Provider[],
 ): RouteDecision => {
   const pool = providers ?? listProviders();
-  const selection = selectProviderForModel(decision.resolvedModel, pool);
+  const selection = selectProviderForModel(decision.resolvedModel, pool, decision.protocol ?? "chat_completions");
   if (!selection) {
     return { ...decision, providerId: "default", fallbackProviderIds: [] };
   }
@@ -152,13 +154,14 @@ const isSimplePrompt = (req: ChatCompletionsRequest): boolean => {
 };
 
 export const resolveRoute = (
-  req: ChatCompletionsRequest,
+  req: ChatCompletionsRequest & { protocol?: RequestProtocol },
   providers?: Provider[],
 ): RouteDecision => {
   const requestedModel = req.model;
+  const protocol = req.protocol ?? "chat_completions";
   const finalize = (
-    decision: Omit<RouteDecision, "providerId" | "fallbackProviderIds">,
-  ): RouteDecision => applyProviderSelection(decision, providers);
+    decision: Omit<RouteDecision, "providerId" | "fallbackProviderIds" | "protocol">,
+  ): RouteDecision => applyProviderSelection({ ...decision, protocol }, providers);
 
   if (isAnthropicModel(requestedModel)) {
     const anthropicMapped = config.anthropicModelMap[requestedModel];

--- a/src/providers/anthropic-sdk.ts
+++ b/src/providers/anthropic-sdk.ts
@@ -220,12 +220,22 @@ export const createAnthropicSdkProvider = (cfg: ProviderConfig): Provider => {
           response.usage.output_tokens,
         );
         const callerAgentId = resolveCallerAgentId(context);
+        const respUsage = response.usage as {
+          input_tokens: number;
+          output_tokens: number;
+          cache_read_input_tokens?: number | null;
+          cache_creation_input_tokens?: number | null;
+        };
+        const cacheRead = respUsage.cache_read_input_tokens ?? 0;
+        const cacheCreation = respUsage.cache_creation_input_tokens ?? 0;
         setSpanAttrs({
           "prov.llm.prompt_tokens": response.usage.input_tokens,
           "prov.llm.completion_tokens": response.usage.output_tokens,
           "prov.llm.total_tokens": response.usage.input_tokens + response.usage.output_tokens,
           "prov.llm.stop_reason": anthropicStopReasonToOpenAI(response.stop_reason) ?? "unknown",
           "cost.usd": costUsd,
+          ...(cacheRead > 0 ? { "prov.llm.cache_read_input_tokens": cacheRead } : {}),
+          ...(cacheCreation > 0 ? { "prov.llm.cache_creation_input_tokens": cacheCreation } : {}),
           ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
         });
 
@@ -307,6 +317,12 @@ export const createAnthropicSdkProvider = (cfg: ProviderConfig): Provider => {
         "prov.llm.total_tokens": result.inputTokens + result.outputTokens,
         "prov.llm.stop_reason": anthropicStopReasonToOpenAI(result.stopReason) ?? "unknown",
         "cost.usd": costUsd,
+        ...(result.cacheReadTokens > 0
+          ? { "prov.llm.cache_read_input_tokens": result.cacheReadTokens }
+          : {}),
+        ...(result.cacheCreationTokens > 0
+          ? { "prov.llm.cache_creation_input_tokens": result.cacheCreationTokens }
+          : {}),
         ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),
       });
     });

--- a/src/providers/anthropic-sdk.ts
+++ b/src/providers/anthropic-sdk.ts
@@ -334,6 +334,7 @@ export const createAnthropicSdkProvider = (cfg: ProviderConfig): Provider => {
     id: cfg.id,
     kind: cfg.kind,
     models: cfg.models,
+    protocols: cfg.protocols ?? ["chat_completions"],
     call,
     stream,
     __resetClient: resetClient,

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -8,7 +8,7 @@ import {
   buildMockResponsesResponse,
   DownstreamRequestError,
   downstreamLogger,
-  emitDownstreamResponsesAsSse,
+  emitMockResponsesAsSse,
   emitDownstreamResponseAsSse,
   parseJsonSafely,
   type DownstreamRequestContext,
@@ -16,6 +16,15 @@ import {
 } from "../downstream.js";
 import { registerAdapter } from "./registry.js";
 import type { Provider, ProviderConfig } from "./types.js";
+
+// Drop Mux-internal fields before forwarding to the downstream API. `runtime`
+// and `protocol` are added by Mux for routing/policy and are not part of the
+// OpenAI request schema; strict downstreams (additional_properties_strict)
+// will 400 if we leak them.
+const stripMuxInternalFields = <T extends Record<string, unknown>>(req: T): Omit<T, "runtime" | "protocol"> => {
+  const { runtime: _runtime, protocol: _protocol, ...rest } = req;
+  return rest;
+};
 
 const resolveAuthHeaderForProvider = (
   cfg: ProviderConfig,
@@ -94,7 +103,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
 
-      const payload = { ...req, model: route.resolvedModel };
+      const payload = { ...stripMuxInternalFields(req), model: route.resolvedModel };
       const url = `${cfg.baseUrl}/chat/completions`;
       logDownstreamRequest(cfg, req, route, url, false);
       const startedAt = Date.now();
@@ -178,7 +187,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
 
-      const payload = { ...req, model: route.resolvedModel };
+      const payload = { ...stripMuxInternalFields(req), model: route.resolvedModel };
       const url = `${cfg.baseUrl}/responses`;
       downstreamLogger.info({
         event: "mux.downstream_request",
@@ -217,7 +226,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
     context?: DownstreamRequestContext,
   ): Promise<void> => {
     if (!cfg.baseUrl) {
-      emitDownstreamResponsesAsSse(res, buildMockResponsesResponse(req, route));
+      emitMockResponsesAsSse(res, buildMockResponsesResponse(req, route));
       return;
     }
 
@@ -232,7 +241,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
 
-      const payload = { ...req, model: route.resolvedModel, stream: true };
+      const payload = { ...stripMuxInternalFields(req), model: route.resolvedModel, stream: true };
       const url = `${cfg.baseUrl}/responses`;
       downstreamLogger.info({
         event: "mux.downstream_request",
@@ -303,7 +312,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
 
-      const payload = { ...req, model: route.resolvedModel, stream: true };
+      const payload = { ...stripMuxInternalFields(req), model: route.resolvedModel, stream: true };
       const url = `${cfg.baseUrl}/chat/completions`;
       logDownstreamRequest(cfg, req, route, url, true);
       const startedAt = Date.now();

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -2,11 +2,13 @@ import type express from "express";
 
 import { setSpanAttrs, withLlmSpan } from "../tracing.js";
 import { computeCostUsd, resolveCallerAgentId } from "./cost.js";
-import type { ChatCompletionsRequest, RouteDecision } from "../types.js";
+import type { ChatCompletionsRequest, ResponsesRequest, RouteDecision } from "../types.js";
 import {
   buildMockResponse,
+  buildMockResponsesResponse,
   DownstreamRequestError,
   downstreamLogger,
+  emitDownstreamResponsesAsSse,
   emitDownstreamResponseAsSse,
   parseJsonSafely,
   type DownstreamRequestContext,
@@ -68,6 +70,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
     throw new Error(`createOpenAICompatibleProvider: wrong kind=${cfg.kind}`);
   }
   const timeoutMs = cfg.timeoutMs ?? 30_000;
+  const protocols = cfg.protocols ?? ["chat_completions"];
 
   const call = async (
     req: ChatCompletionsRequest,
@@ -149,6 +152,127 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
         });
 
         return result;
+      } finally {
+        clearTimeout(timeout);
+      }
+    });
+  };
+
+  const callResponses = async (
+    req: ResponsesRequest,
+    route: RouteDecision,
+    context?: DownstreamRequestContext,
+  ): Promise<Record<string, unknown>> => {
+    if (!cfg.baseUrl) {
+      return buildMockResponsesResponse(req, route);
+    }
+
+    return withLlmSpan("openai-compatible", route.resolvedModel, async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        ...(cfg.extraHeaders ?? {}),
+      };
+      const auth = resolveAuthHeaderForProvider(cfg, context);
+      if (auth) headers[auth.header] = auth.value;
+
+      const payload = { ...req, model: route.resolvedModel };
+      const url = `${cfg.baseUrl}/responses`;
+      downstreamLogger.info({
+        event: "mux.downstream_request",
+        protocol: "responses",
+        providerId: cfg.id,
+        requestedModel: route.requestedModel,
+        resolvedModel: route.resolvedModel,
+        url,
+        authMode: cfg.auth.mode,
+        timeoutMs: cfg.timeoutMs ?? null,
+        streamed: false,
+      });
+
+      try {
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          const body = await parseJsonSafely(response);
+          throw new DownstreamRequestError(response.status, body);
+        }
+        return await response.json() as Record<string, unknown>;
+      } finally {
+        clearTimeout(timeout);
+      }
+    });
+  };
+
+  const streamResponses = async (
+    req: ResponsesRequest,
+    route: RouteDecision,
+    res: express.Response,
+    context?: DownstreamRequestContext,
+  ): Promise<void> => {
+    if (!cfg.baseUrl) {
+      emitDownstreamResponsesAsSse(res, buildMockResponsesResponse(req, route));
+      return;
+    }
+
+    await withLlmSpan("openai-compatible", route.resolvedModel, async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        ...(cfg.extraHeaders ?? {}),
+      };
+      const auth = resolveAuthHeaderForProvider(cfg, context);
+      if (auth) headers[auth.header] = auth.value;
+
+      const payload = { ...req, model: route.resolvedModel, stream: true };
+      const url = `${cfg.baseUrl}/responses`;
+      downstreamLogger.info({
+        event: "mux.downstream_request",
+        protocol: "responses",
+        providerId: cfg.id,
+        requestedModel: route.requestedModel,
+        resolvedModel: route.resolvedModel,
+        url,
+        authMode: cfg.auth.mode,
+        timeoutMs: cfg.timeoutMs ?? null,
+        streamed: true,
+      });
+
+      try {
+        const response = await fetch(url, { method: "POST", headers, body: JSON.stringify(payload), signal: controller.signal });
+        if (!response.ok) {
+          const body = await parseJsonSafely(response);
+          throw new DownstreamRequestError(response.status, body);
+        }
+        if (!response.body) throw new DownstreamRequestError(502, { message: "empty response body from downstream" });
+        if (!res.headersSent) {
+          res.status(200);
+          res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+          res.setHeader("Cache-Control", "no-cache, no-transform");
+          res.setHeader("Connection", "keep-alive");
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value && value.length) res.write(decoder.decode(value, { stream: true }));
+          }
+          const tail = decoder.decode();
+          if (tail) res.write(tail);
+        } finally {
+          try { reader.releaseLock(); } catch {}
+        }
+        res.end();
       } finally {
         clearTimeout(timeout);
       }
@@ -263,8 +387,11 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
     id: cfg.id,
     kind: cfg.kind,
     models: cfg.models,
+    protocols,
     call,
     stream,
+    callResponses: protocols.includes("responses") ? callResponses : undefined,
+    streamResponses: protocols.includes("responses") ? streamResponses : undefined,
   };
 };
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -53,7 +53,7 @@ const synthesizeLegacyProvider = (): ProviderConfig | null => {
     id: "default",
     kind: "openai-compatible",
     baseUrl: config.downstreamBaseUrl,
-    protocols: ((process.env.DOWNSTREAM_PROTOCOLS || "").split(",").map((s) => s.trim()).filter((s) => s === "chat_completions" || s === "responses") as Array<"chat_completions" | "responses">).length ? ((process.env.DOWNSTREAM_PROTOCOLS || "").split(",").map((s) => s.trim()).filter((s) => s === "chat_completions" || s === "responses") as Array<"chat_completions" | "responses">) : ["chat_completions"],
+    protocols: config.downstreamProtocols,
     auth,
     extraHeaders: config.downstreamExtraHeaders,
     timeoutMs: config.downstreamTimeoutMs,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -28,6 +28,7 @@ const synthesizeLegacyProvider = (): ProviderConfig | null => {
       id: "default",
       kind: "anthropic-sdk",
       baseUrl: config.anthropicBaseUrl,
+      protocols: ["chat_completions"],
       auth: oauth
         ? { mode: "anthropic-oauth", oauthToken: oauth, baseUrl: config.anthropicBaseUrl }
         : { mode: "anthropic-api-key", apiKey: apiKey!, baseUrl: config.anthropicBaseUrl },
@@ -52,6 +53,7 @@ const synthesizeLegacyProvider = (): ProviderConfig | null => {
     id: "default",
     kind: "openai-compatible",
     baseUrl: config.downstreamBaseUrl,
+    protocols: ((process.env.DOWNSTREAM_PROTOCOLS || "").split(",").map((s) => s.trim()).filter((s) => s === "chat_completions" || s === "responses") as Array<"chat_completions" | "responses">).length ? ((process.env.DOWNSTREAM_PROTOCOLS || "").split(",").map((s) => s.trim()).filter((s) => s === "chat_completions" || s === "responses") as Array<"chat_completions" | "responses">) : ["chat_completions"],
     auth,
     extraHeaders: config.downstreamExtraHeaders,
     timeoutMs: config.downstreamTimeoutMs,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -2,6 +2,8 @@ import type express from "express";
 
 import type {
   ChatCompletionsRequest,
+  RequestProtocol,
+  ResponsesRequest,
   RouteDecision,
 } from "../types.js";
 
@@ -22,6 +24,7 @@ export type ProviderModelConfig = {
 };
 
 export type ProviderConfig = {
+  protocols?: RequestProtocol[];
   id: string;
   kind: ProviderKind;
   baseUrl?: string | null;
@@ -58,6 +61,7 @@ export type Provider = {
   id: string;
   kind: ProviderKind;
   models: ProviderModelConfig[];
+  protocols: RequestProtocol[];
   call(
     req: ChatCompletionsRequest,
     route: RouteDecision,
@@ -65,6 +69,17 @@ export type Provider = {
   ): Promise<DownstreamResponseLike>;
   stream(
     req: ChatCompletionsRequest,
+    route: RouteDecision,
+    res: express.Response,
+    ctx?: DownstreamRequestContextLike,
+  ): Promise<void>;
+  callResponses?(
+    req: ResponsesRequest,
+    route: RouteDecision,
+    ctx?: DownstreamRequestContextLike,
+  ): Promise<unknown>;
+  streamResponses?(
+    req: ResponsesRequest,
     route: RouteDecision,
     res: express.Response,
     ctx?: DownstreamRequestContextLike,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,21 @@ export type ChatMessage = {
   tool_call_id?: string;
 };
 
+export type ResponsesInputItem = string | Record<string, unknown>;
+
+export type ResponsesRequest = {
+  model: string;
+  input?: ResponsesInputItem | ResponsesInputItem[];
+  stream?: boolean;
+  temperature?: number;
+  max_output_tokens?: number;
+  runtime?: string;
+  tools?: unknown[];
+  [key: string]: unknown;
+};
+
+export type RequestProtocol = "chat_completions" | "responses";
+
 export type ChatCompletionsRequest = {
   model: string;
   messages: ChatMessage[];
@@ -50,6 +65,7 @@ export type ChatCompletionsRequest = {
 };
 
 export type RouteDecision = {
+  protocol?: RequestProtocol;
   requestedModel: string;
   resolvedModel: string;
   routeReason: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,10 @@ export type ChatCompletionsRequest = {
   temperature?: number;
   max_tokens?: number;
   runtime?: string;
+  // Mux-internal: which public protocol the caller hit. Set by the route
+  // handlers in app.ts and consumed by policy.ts when filtering providers.
+  // Not forwarded downstream (stripped in openai-compatible adapter).
+  protocol?: RequestProtocol;
   tools?: OpenAIToolDef[];
   tool_choice?: OpenAIToolChoice;
 };

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -32,6 +32,36 @@ describe("createApp", () => {
     expect(res.body.error.type).toBe("invalid_request_error");
   });
 
+
+  it("rejects invalid responses payloads", async () => {
+    const res = await request(app).post("/v1/responses").send({ input: "hello" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.type).toBe("invalid_request_error");
+  });
+
+  it("returns a stubbed responses payload when responses protocol is enabled", async () => {
+    const previousProtocols = process.env.DOWNSTREAM_PROTOCOLS;
+    process.env.DOWNSTREAM_PROTOCOLS = "chat_completions,responses";
+    __resetProviderRegistryForTests();
+
+    const res = await request(app)
+      .post("/v1/responses")
+      .set("x-runtime", "openclaw")
+      .send({
+        model: "gpt-5.4",
+        input: [{ role: "user", content: [{ type: "input_text", text: "say hi" }] }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe("response");
+    expect(res.body.model).toBe("gpt-5.4");
+    expect(JSON.stringify(res.body)).toContain("requested=gpt-5.4");
+
+    process.env.DOWNSTREAM_PROTOCOLS = previousProtocols;
+    __resetProviderRegistryForTests();
+  });
+
   it("returns a stubbed chat completion and honors runtime header", async () => {
     const res = await request(app)
       .post("/v1/chat/completions")

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -1216,8 +1216,8 @@ describe("streamAnthropicToOpenAI", () => {
     const frames = parseSseFrames(res.writes);
     expect(frames[frames.length - 1]).toBe("[DONE]");
     const chunks = frames.filter((f): f is Record<string, unknown> => f !== "[DONE]");
-    // 1: role, 2: "hel", 3: "lo", 4: final finish_reason
-    expect(chunks).toHaveLength(4);
+    // 1: role, 2: "hel", 3: "lo", 4: finish_reason, 5: usage
+    expect(chunks).toHaveLength(5);
 
     const firstDelta = (chunks[0] as any).choices[0].delta;
     expect(firstDelta).toEqual({ role: "assistant" });
@@ -1226,9 +1226,14 @@ describe("streamAnthropicToOpenAI", () => {
     expect((chunks[1] as any).choices[0].delta).toEqual({ content: "hel" });
     expect((chunks[2] as any).choices[0].delta).toEqual({ content: "lo" });
 
-    const last = chunks[3] as any;
-    expect(last.choices[0].delta).toEqual({});
-    expect(last.choices[0].finish_reason).toBe("stop");
+    const finish = chunks[3] as any;
+    expect(finish.choices[0].delta).toEqual({});
+    expect(finish.choices[0].finish_reason).toBe("stop");
+
+    // Final chunk is the OpenAI include_usage shape: choices: [] + usage.
+    const usageChunk = chunks[4] as any;
+    expect(usageChunk.choices).toEqual([]);
+    expect(usageChunk.usage).toBeDefined();
     expect(res.ended).toBe(true);
   });
 
@@ -1266,8 +1271,8 @@ describe("streamAnthropicToOpenAI", () => {
     const chunks = parseSseFrames(res.writes).filter(
       (f): f is Record<string, unknown> => f !== "[DONE]",
     );
-    // Role chunk + tool_use start + 2 argument fragments + final.
-    expect(chunks).toHaveLength(5);
+    // Role chunk + tool_use start + 2 argument fragments + finish_reason + usage.
+    expect(chunks).toHaveLength(6);
 
     const toolStart = (chunks[1] as any).choices[0].delta.tool_calls;
     expect(toolStart).toEqual([
@@ -1286,8 +1291,11 @@ describe("streamAnthropicToOpenAI", () => {
     const frag2 = (chunks[3] as any).choices[0].delta.tool_calls;
     expect(frag2).toEqual([{ index: 0, function: { arguments: 'tc/hosts"}' } }]);
 
-    // Final chunk uses tool_use → tool_calls mapping.
+    // finish_reason chunk maps tool_use → tool_calls.
     expect((chunks[4] as any).choices[0].finish_reason).toBe("tool_calls");
+    // Trailing usage chunk (choices: []).
+    expect((chunks[5] as any).choices).toEqual([]);
+    expect((chunks[5] as any).usage).toBeDefined();
   });
 
   it("writes a terminal [stream error:] chunk when the event source throws", async () => {
@@ -1398,6 +1406,180 @@ describe("streamAnthropicToOpenAI", () => {
     // Must be the last seen value (25), NOT a sum (3 + 7 + 25 = 35).
     expect(respEvent?.outputTokens).toBe(25);
   });
+
+  it("emits a final usage chunk with prompt_tokens_details.cached_tokens when Anthropic reports cache hits", async () => {
+    const res = makeStubRes();
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_c",
+          usage: {
+            input_tokens: 12,
+            output_tokens: 0,
+            cache_read_input_tokens: 5000,
+            cache_creation_input_tokens: 300,
+          },
+        },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 7 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const result = await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const chunks = parseSseFrames(res.writes).filter(
+      (f): f is Record<string, unknown> => f !== "[DONE]",
+    );
+    const usageChunk = chunks[chunks.length - 1] as any;
+    expect(usageChunk.choices).toEqual([]);
+    // Rolls cache tokens into prompt_tokens to match non-streaming toOpenAIResponse.
+    // input(12) + cache_read(5000) + cache_creation(300) = 5312
+    expect(usageChunk.usage.prompt_tokens).toBe(5312);
+    expect(usageChunk.usage.completion_tokens).toBe(7);
+    expect(usageChunk.usage.total_tokens).toBe(5319);
+    expect(usageChunk.usage.prompt_tokens_details).toEqual({ cached_tokens: 5000 });
+
+    // StreamResult carries the cache buckets so the adapter can set span attrs.
+    expect(result.cacheReadTokens).toBe(5000);
+    expect(result.cacheCreationTokens).toBe(300);
+    expect(result.inputTokens).toBe(12);
+    expect(result.outputTokens).toBe(7);
+  });
+
+  it("omits prompt_tokens_details on the usage chunk when no cache fields are reported", async () => {
+    const res = makeStubRes();
+    const events = [
+      {
+        type: "message_start",
+        message: { id: "msg_nc", usage: { input_tokens: 20, output_tokens: 0 } },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 4 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const result = await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const chunks = parseSseFrames(res.writes).filter(
+      (f): f is Record<string, unknown> => f !== "[DONE]",
+    );
+    const usageChunk = chunks[chunks.length - 1] as any;
+    expect(usageChunk.usage.prompt_tokens).toBe(20);
+    expect(usageChunk.usage.completion_tokens).toBe(4);
+    expect(usageChunk.usage.total_tokens).toBe(24);
+    expect(usageChunk.usage.prompt_tokens_details).toBeUndefined();
+
+    expect(result.cacheReadTokens).toBe(0);
+    expect(result.cacheCreationTokens).toBe(0);
+  });
+
+  it("updates cache token counts when message_delta carries later usage values (last value wins)", async () => {
+    const res = makeStubRes();
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_u",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 0,
+            cache_read_input_tokens: 100,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "x" } },
+      { type: "content_block_stop", index: 0 },
+      // Anthropic may update usage on message_delta for some models — latest wins.
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: {
+          output_tokens: 5,
+          cache_read_input_tokens: 999,
+          cache_creation_input_tokens: 50,
+        },
+      },
+      { type: "message_stop" },
+    ];
+
+    const result = await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    expect(result.cacheReadTokens).toBe(999);
+    expect(result.cacheCreationTokens).toBe(50);
+  });
+
+  it("logs cacheReadTokens and cacheCreationTokens on the mux.anthropic_response event", async () => {
+    const res = makeStubRes();
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_log",
+          usage: {
+            input_tokens: 3,
+            output_tokens: 0,
+            cache_read_input_tokens: 8740,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const infoSpy = vi.spyOn(downstreamLogger, "info");
+
+    await streamAnthropicToOpenAI(
+      eventsAsAsyncIterable(events as any),
+      res as unknown as import("express").Response,
+      "claude-sonnet-4-6",
+      { requestedModel: "claude-sonnet-4-6", resolvedModel: "claude-sonnet-4-6" },
+    );
+
+    const calls = infoSpy.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const respEvent = calls.find((c) => c.event === "mux.anthropic_response");
+    expect(respEvent).toBeDefined();
+    expect(respEvent?.cacheReadTokens).toBe(8740);
+    expect(respEvent?.cacheCreationTokens).toBe(0);
+  });
 });
 
 describe("streamDownstream", () => {
@@ -1499,9 +1681,14 @@ describe("streamDownstream", () => {
         .filter(Boolean)
         .join("");
       expect(content).toBe("hi there");
-      const final = chunks[chunks.length - 1] as any;
+      // Trailing chunks: [..., finish_reason chunk, usage chunk].
+      // The usage chunk has choices: []; finish_reason is on the one before it.
+      const finishChunk = chunks[chunks.length - 2] as any;
       // Anthropic end_turn → OpenAI stop (via anthropicStopReasonToOpenAI).
-      expect(final.choices[0].finish_reason).toBe("stop");
+      expect(finishChunk.choices[0].finish_reason).toBe("stop");
+      const usageChunk = chunks[chunks.length - 1] as any;
+      expect(usageChunk.choices).toEqual([]);
+      expect(usageChunk.usage).toBeDefined();
     } finally {
       restore();
     }


### PR DESCRIPTION
## Summary
- add native `POST /v1/responses` handling in the Express app
- allow providers to declare supported protocols and route responses requests only to responses-capable downstreams
- add openai-compatible downstream passthrough + tests/docs for the MVP flow

## Testing
- npm test
- npm run check

Closes #40