### PR TITLE
feat: externalize routing rules and add explain endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,3 +129,27 @@ TRACE_PROMPT_PREVIEW_REDACTED_VALUE=[redacted]
 # endpoint is /v1/chat/completions, so the /v1 belongs in the baseUrl, not in
 # the client's path.
 PROVIDERS=
+
+# Declarative routing rules (optional)
+# Ordered list. First matching rule wins after MODEL_MAP / ANTHROPIC_MODEL_MAP,
+# before built-in heuristics. This keeps defaults intact while letting operators
+# override common cases without editing TypeScript.
+# Example:
+# ROUTING_RULES=[
+#   {
+#     "id": "simple-openclaw-gpt4o",
+#     "runtime": "openclaw",
+#     "requestedModel": "gpt-4o",
+#     "maxPromptLength": 120,
+#     "resolvedModel": "gpt-4o-mini"
+#   },
+#   {
+#     "id": "max-debug-to-sonnet",
+#     "runtime": ["max", "pi-mono"],
+#     "requestedModel": ["claude-3-7-sonnet-latest", "claude-sonnet-4-6"],
+#     "promptIncludesAny": ["debug", "stack trace", "typescript"],
+#     "resolvedModel": "claude-sonnet-4-6",
+#     "routeReason": "config:max_debug_rule"
+#   }
+# ]
+ROUTING_RULES=

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Mux is the control point for that problem.
 - support for routing across models and providers
 - fallback and escalation handling
 - structured routing metadata for observability
+- an explain/dry-run route endpoint for debugging policy decisions
 
 ## Architecture
 
@@ -90,6 +91,59 @@ Routing for Max runtime requests is evaluated on the **last user message only** 
 
 Route decisions are logged with: `runtime`, `requestedModel`, `resolvedModel`, `routeReason`, `provider`, `backendTarget`.
 
+### Declarative routing rules
+
+If you want something more flexible than the built-in heuristics in `src/policy.ts`,
+set `ROUTING_RULES` to an ordered JSON array. First match wins.
+
+Supported fields per rule:
+
+- `id` — required unique identifier
+- `protocols` — optional array of `chat_completions` / `responses`
+- `runtime` — optional string or string[]
+- `requestedModel` — optional string or string[]
+- `promptIncludesAny` — optional string[] keyword match on the last user message
+- `maxPromptLength` — optional upper bound for last-user-message length
+- `resolvedModel` — required routed model
+- `routeReason` — optional custom reason string
+
+Example:
+
+```bash
+ROUTING_RULES='[
+  {
+    "id": "simple-openclaw-gpt4o",
+    "runtime": "openclaw",
+    "requestedModel": "gpt-4o",
+    "maxPromptLength": 120,
+    "resolvedModel": "gpt-4o-mini"
+  }
+]'
+```
+
+Config rules are applied after `MODEL_MAP` / `ANTHROPIC_MODEL_MAP` and before the built-in heuristics, so explicit overrides still win and defaults remain as fallback behavior.
+
+### Explain / dry-run route decisions
+
+Mux exposes a no-downstream debug endpoint:
+
+```bash
+curl -s http://localhost:8787/v1/route/resolve \
+  -H 'content-type: application/json' \
+  -H 'x-runtime: openclaw' \
+  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"say hi"}]}' | jq
+```
+
+For Responses-style callers:
+
+```bash
+curl -s http://localhost:8787/v1/route/resolve \
+  -H 'content-type: application/json' \
+  -d '{"protocol":"responses","model":"gpt-4o","input":[{"role":"user","content":[{"type":"input_text","text":"say hi"}]}]}' | jq
+```
+
+This returns the resolved route metadata, including `matchedRuleId` when a declarative rule fired.
+
 ### Enable native Responses routing
 
 If you want Mux to accept `POST /v1/responses` for a legacy/default `openai-compatible` downstream, set:
@@ -130,6 +184,7 @@ curl -s http://localhost:8787/v1/responses \
 | `DOWNSTREAM_TIMEOUT_MS` | `30000` | Request timeout in ms |
 | `DOWNSTREAM_PROTOCOLS` | `chat_completions` | Comma-separated legacy/default downstream protocols (`chat_completions`, `responses`) |
 | `DOWNSTREAM_MOCK_FALLBACK` | `true` (dev) | Return mock response when no backend configured |
+| `ROUTING_RULES` | `[]` | Ordered JSON array of declarative routing rules applied before built-in heuristics |
 | `ANTHROPIC_OAUTH_TOKEN` | — | OAuth token (preferred for anthropic-sdk) |
 | `ANTHROPIC_API_KEY` | — | API key fallback for anthropic-sdk |
 | `ANTHROPIC_BASE_URL` | — | Override Anthropic API URL (supports proxies) |

--- a/src/app.ts
+++ b/src/app.ts
@@ -105,6 +105,31 @@ const normalizeResponsesInputToMessages = (input: ResponsesRequest["input"]): Ch
   return [{ role: "user", content }];
 };
 
+const buildRoutingRequest = (body: Record<string, unknown>, req: express.Request): ChatCompletionsRequest | null => {
+  const runtime = extractRuntime(body as { runtime?: string }, req);
+  const protocol = body.protocol === "responses" ? "responses" : "chat_completions";
+
+  if (protocol === "responses") {
+    if (typeof body.model !== "string") return null;
+    return {
+      model: body.model,
+      messages: normalizeResponsesInputToMessages(body.input as ResponsesRequest["input"]),
+      stream: Boolean(body.stream),
+      runtime,
+      protocol,
+    };
+  }
+
+  if (typeof body.model !== "string" || !Array.isArray(body.messages)) return null;
+  return {
+    ...(body as ChatCompletionsRequest),
+    model: body.model,
+    messages: body.messages as ChatMessage[],
+    runtime,
+    protocol,
+  };
+};
+
 const logRouteDecision = (params: {
   protocol: RequestProtocol;
   runtime: string;
@@ -142,6 +167,7 @@ const logRouteDecision = (params: {
     routeReason: route.routeReason,
     provider: route.provider,
     providerId: route.providerId,
+    matchedRuleId: route.matchedRuleId,
     backendTarget: route.backendTarget,
     downstreamMode: config.downstreamMode,
   });
@@ -248,6 +274,22 @@ export const createApp = () => {
       },
       ...(ready ? {} : { reasons: problems }),
     });
+  });
+
+  app.post("/v1/route/resolve", (req, res) => {
+    const routingRequest = buildRoutingRequest(req.body as Record<string, unknown>, req);
+
+    if (!routingRequest) {
+      return res.status(400).json({
+        error: {
+          message: "Invalid payload: expected { model, messages[] } or { protocol: 'responses', model, input }",
+          type: "invalid_request_error",
+        },
+      });
+    }
+
+    const route = resolveRoute(routingRequest);
+    return res.status(200).json({ route });
   });
 
   app.post("/v1/chat/completions", async (req, res) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 
 import type { ProviderConfig, ProviderKind } from "./providers/types.js";
-import type { RequestProtocol } from "./types.js";
+import type { RequestProtocol, RoutingRule } from "./types.js";
 
 dotenv.config();
 
@@ -117,6 +117,45 @@ const parseProviders = (input: string | undefined): ProviderConfig[] => {
   }
 };
 
+const toStringArray = (value: unknown): string[] | undefined => {
+  if (typeof value === "string" && value.trim()) return [value.trim()];
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter((v): v is string => typeof v === "string" && v.trim().length > 0).map((v) => v.trim());
+  return out.length > 0 ? out : undefined;
+};
+
+const parseRoutingRules = (input: string | undefined): RoutingRule[] => {
+  if (!input?.trim()) return [];
+  try {
+    const parsed = JSON.parse(input);
+    if (!Array.isArray(parsed)) return [];
+    const out: RoutingRule[] = [];
+    for (const raw of parsed) {
+      if (!raw || typeof raw !== "object") continue;
+      const r = raw as Record<string, unknown>;
+      if (typeof r.id !== "string" || !r.id.trim()) continue;
+      if (typeof r.resolvedModel !== "string" || !r.resolvedModel.trim()) continue;
+      out.push({
+        id: r.id.trim(),
+        protocols: parseProtocols(r.protocols, ["chat_completions"]),
+        runtime: Array.isArray(r.runtime) ? toStringArray(r.runtime) : typeof r.runtime === "string" ? r.runtime.trim() : undefined,
+        requestedModel: Array.isArray(r.requestedModel)
+          ? toStringArray(r.requestedModel)
+          : typeof r.requestedModel === "string"
+            ? r.requestedModel.trim()
+            : undefined,
+        promptIncludesAny: toStringArray(r.promptIncludesAny),
+        maxPromptLength: typeof r.maxPromptLength === "number" && r.maxPromptLength > 0 ? r.maxPromptLength : undefined,
+        resolvedModel: r.resolvedModel.trim(),
+        routeReason: typeof r.routeReason === "string" && r.routeReason.trim() ? r.routeReason.trim() : undefined,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+};
+
 const parseJsonMap = (input: string | undefined): Record<string, string> => {
   if (!input) return {};
 
@@ -166,6 +205,7 @@ export const config = {
   tracePromptPreviewRedactedValue:
     process.env.TRACE_PROMPT_PREVIEW_REDACTED_VALUE || "[redacted]",
   providers: parseProviders(process.env.PROVIDERS),
+  routingRules: parseRoutingRules(process.env.ROUTING_RULES),
   failoverMaxAttempts: parseNonNegativeInt(process.env.FAILOVER_MAX_ATTEMPTS, 1),
   // Inject Anthropic ephemeral prompt-cache breakpoints in the OpenAI →
   // Anthropic translator (system prompt, tools, history). On by default —

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,7 +1,7 @@
 import { config } from "./config.js";
 import { listProviders } from "./providers/registry.js";
 import type { Provider } from "./providers/types.js";
-import type { ChatCompletionsRequest, RouteDecision } from "./types.js";
+import type { ChatCompletionsRequest, RouteDecision, RoutingRule } from "./types.js";
 
 type ProviderSelection = {
   providerId: string;
@@ -65,6 +65,12 @@ const applyProviderSelection = (
 const containsAny = (text: string, cues: string[]): boolean => {
   const lower = text.toLowerCase();
   return cues.some((cue) => lower.includes(cue));
+};
+
+const matchesStringOrList = (value: string, matcher: string | string[] | undefined): boolean => {
+  if (!matcher) return true;
+  if (typeof matcher === "string") return value.toLowerCase() === matcher.toLowerCase();
+  return matcher.some((item) => value.toLowerCase() === item.toLowerCase());
 };
 
 const containsEscalationCue = (text: string): boolean => {
@@ -153,6 +159,44 @@ const isSimplePrompt = (req: ChatCompletionsRequest): boolean => {
   return textLength < 80;
 };
 
+const getLastUserText = (req: ChatCompletionsRequest): string => {
+  const lastUserMsg = [...req.messages].reverse().find((m) => m.role === "user");
+  return lastUserMsg
+    ? typeof lastUserMsg.content === "string"
+      ? lastUserMsg.content
+      : JSON.stringify(lastUserMsg.content)
+    : "";
+};
+
+const matchRoutingRule = (rule: RoutingRule, req: ChatCompletionsRequest, prompt: string): boolean => {
+  const protocol = req.protocol ?? "chat_completions";
+  if (rule.protocols && !rule.protocols.includes(protocol)) return false;
+  if (!matchesStringOrList(req.model, rule.requestedModel)) return false;
+  if (!matchesStringOrList(req.runtime ?? "unknown", rule.runtime)) return false;
+  if (typeof rule.maxPromptLength === "number" && prompt.length > rule.maxPromptLength) return false;
+  if (rule.promptIncludesAny && !containsAny(prompt, rule.promptIncludesAny)) return false;
+  return true;
+};
+
+const resolveConfiguredRule = (
+  req: ChatCompletionsRequest,
+): Omit<RouteDecision, "providerId" | "fallbackProviderIds" | "protocol"> | null => {
+  if (config.routingRules.length === 0) return null;
+  const prompt = getLastUserText(req);
+  for (const rule of config.routingRules) {
+    if (!matchRoutingRule(rule, req, prompt)) continue;
+    return {
+      requestedModel: req.model,
+      resolvedModel: rule.resolvedModel,
+      routeReason: rule.routeReason ?? `config:routing_rule:${rule.id}`,
+      matchedRuleId: rule.id,
+      provider: config.defaultProvider,
+      backendTarget: config.defaultBackendTarget,
+    };
+  }
+  return null;
+};
+
 export const resolveRoute = (
   req: ChatCompletionsRequest,
   providers?: Provider[],
@@ -234,10 +278,12 @@ export const resolveRoute = (
     });
   }
 
-  const lastUserMsg = [...req.messages].reverse().find((m) => m.role === "user");
-  const lastUserText = lastUserMsg
-    ? (typeof lastUserMsg.content === "string" ? lastUserMsg.content : JSON.stringify(lastUserMsg.content))
-    : "";
+  const configuredRule = resolveConfiguredRule(req);
+  if (configuredRule) {
+    return finalize(configuredRule);
+  }
+
+  const lastUserText = getLastUserText(req);
   const escalation = containsEscalationCue(lastUserText);
 
   if (requestedModel === "gpt-4o" && !escalation) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,17 @@ export type ResponsesRequest = {
 
 export type RequestProtocol = "chat_completions" | "responses";
 
+export type RoutingRule = {
+  id: string;
+  protocols?: RequestProtocol[];
+  runtime?: string | string[];
+  requestedModel?: string | string[];
+  promptIncludesAny?: string[];
+  maxPromptLength?: number;
+  resolvedModel: string;
+  routeReason?: string;
+};
+
 export type ChatCompletionsRequest = {
   model: string;
   messages: ChatMessage[];
@@ -73,6 +84,7 @@ export type RouteDecision = {
   requestedModel: string;
   resolvedModel: string;
   routeReason: string;
+  matchedRuleId?: string;
   // Legacy descriptive fields (kind + target). Kept for log/dashboard
   // compatibility. New code should use `providerId` for dispatch.
   provider: string;

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -11,6 +11,7 @@ describe("createApp", () => {
     config.downstreamBaseUrl = null;
     config.downstreamMockFallbackEnabled = true;
     config.modelMap = {};
+    config.routingRules = [];
   });
 
   const app = createApp();
@@ -234,5 +235,46 @@ describe("createApp", () => {
     config.downstreamBaseUrl = previousBaseUrl;
     config.downstreamMockFallbackEnabled = previousFallback;
     __resetProviderRegistryForTests();
+  });
+
+  it("explains a configured route decision without calling downstream", async () => {
+    const previousRoutingRules = config.routingRules;
+    config.routingRules = [
+      {
+        id: "simple-openclaw-override",
+        runtime: "openclaw",
+        requestedModel: "gpt-4o",
+        maxPromptLength: 100,
+        resolvedModel: "gpt-4.1-mini",
+      },
+    ];
+
+    const res = await request(app)
+      .post("/v1/route/resolve")
+      .set("x-runtime", "openclaw")
+      .send({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "say hi" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.route.resolvedModel).toBe("gpt-4.1-mini");
+    expect(res.body.route.matchedRuleId).toBe("simple-openclaw-override");
+
+    config.routingRules = previousRoutingRules;
+  });
+
+  it("explains responses routing payloads", async () => {
+    const res = await request(app)
+      .post("/v1/route/resolve")
+      .send({
+        protocol: "responses",
+        model: "gpt-4o",
+        input: [{ role: "user", content: [{ type: "input_text", text: "say hi" }] }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.route.protocol).toBe("responses");
+    expect(res.body.route.resolvedModel).toBe("gpt-4o-mini");
   });
 });

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -319,4 +319,61 @@ describe("resolveRoute", () => {
     config.modelMap = previousModelMap;
     config.anthropicModelMap = previousAnthropicModelMap;
   });
+
+  it("applies configured routing rules before built-in heuristics", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    const previousRoutingRules = config.routingRules;
+    config.modelMap = {};
+    config.anthropicModelMap = {};
+    config.routingRules = [
+      {
+        id: "force-cheap-gpt4o",
+        requestedModel: "gpt-4o",
+        maxPromptLength: 500,
+        resolvedModel: "gpt-4.1-mini",
+      },
+    ];
+
+    const route = resolveRoute({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "say hi" }],
+    });
+
+    expect(route.resolvedModel).toBe("gpt-4.1-mini");
+    expect(route.routeReason).toBe("config:routing_rule:force-cheap-gpt4o");
+    expect(route.matchedRuleId).toBe("force-cheap-gpt4o");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+    config.routingRules = previousRoutingRules;
+  });
+
+  it("falls back to built-in heuristics when no configured rule matches", () => {
+    const previousModelMap = config.modelMap;
+    const previousAnthropicModelMap = config.anthropicModelMap;
+    const previousRoutingRules = config.routingRules;
+    config.modelMap = {};
+    config.anthropicModelMap = {};
+    config.routingRules = [
+      {
+        id: "only-max",
+        runtime: "max",
+        requestedModel: "gpt-4o",
+        resolvedModel: "gpt-4.1-mini",
+      },
+    ];
+
+    const route = resolveRoute({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "say hi" }],
+    });
+
+    expect(route.resolvedModel).toBe("gpt-4o-mini");
+    expect(route.routeReason).toBe("heuristic:downgrade_simple_prompt");
+
+    config.modelMap = previousModelMap;
+    config.anthropicModelMap = previousAnthropicModelMap;
+    config.routingRules = previousRoutingRules;
+  });
 });


### PR DESCRIPTION
## Summary
- add ordered `ROUTING_RULES` config for declarative routing before built-in heuristics
- add `POST /v1/route/resolve` explain/dry-run endpoint for chat and responses payloads
- document and test the new routing behavior

## Testing
- npm run check
- npm test

Closes #59