### PR TITLE
fix: validate startup config and dotenv examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ NODE_ENV=development
 MODEL_MAP={"gpt-4o":"gpt-4o-mini"}
 # Optional Anthropic-only routing map. Applied first for Claude model requests.
 # Example: {"claude-3-7-sonnet-latest":"claude-sonnet-4-5"}
-ANTHROPIC_MODEL_MAP={}
+ANTHROPIC_MODEL_MAP={"claude-3-7-sonnet-latest":"claude-sonnet-4-5"}
 
 # Route metadata
 DEFAULT_PROVIDER=openai-compatible
@@ -21,7 +21,7 @@ DOWNSTREAM_MODE=openai-compatible
 # OpenAI-compatible downstream (used when DOWNSTREAM_MODE=openai-compatible)
 DOWNSTREAM_BASE_URL=http://localhost:4000/v1
 # Optional key used for downstream auth, based on DOWNSTREAM_AUTH_MODE
-DOWNSTREAM_API_KEY=
+DOWNSTREAM_API_KEY=your-downstream-api-key
 # How Mux authenticates to downstream: bearer | x-api-key | passthrough | none
 # - bearer: sends Authorization: Bearer <DOWNSTREAM_API_KEY>
 # - x-api-key: sends x-api-key: <DOWNSTREAM_API_KEY>
@@ -30,7 +30,7 @@ DOWNSTREAM_API_KEY=
 DOWNSTREAM_AUTH_MODE=bearer
 # Optional JSON map of additional static headers sent to downstream
 # Example: {"anthropic-version":"2023-06-01"}
-DOWNSTREAM_EXTRA_HEADERS={}
+DOWNSTREAM_EXTRA_HEADERS={"anthropic-version":"2023-06-01"}
 # Request timeout for downstream call (milliseconds)
 DOWNSTREAM_TIMEOUT_MS=30000
 # Comma-separated protocols the legacy/default downstream supports.
@@ -128,7 +128,7 @@ TRACE_PROMPT_PREVIEW_REDACTED_VALUE=[redacted]
 # Most OpenAI-SDK-style clients append /chat/completions to baseUrl — Mux's
 # endpoint is /v1/chat/completions, so the /v1 belongs in the baseUrl, not in
 # the client's path.
-PROVIDERS=
+PROVIDERS=[]
 
 # Declarative routing rules (optional)
 # Ordered list. First matching rule wins after MODEL_MAP / ANTHROPIC_MODEL_MAP,
@@ -152,4 +152,4 @@ PROVIDERS=
 #     "routeReason": "config:max_debug_rule"
 #   }
 # ]
-ROUTING_RULES=
+ROUTING_RULES=[]

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,28 +5,69 @@ import type { RequestProtocol, RoutingRule } from "./types.js";
 
 dotenv.config();
 
-const parseModelMap = (input: string | undefined): Record<string, string> => {
-  return parseJsonMap(input);
+type DownstreamAuthMode = "none" | "bearer" | "x-api-key" | "passthrough";
+type DownstreamMode = "openai-compatible" | "anthropic-sdk";
+
+type ParseErrorCode =
+  | "invalid_number"
+  | "invalid_non_negative_int"
+  | "invalid_boolean"
+  | "invalid_json"
+  | "invalid_json_type"
+  | "invalid_enum"
+  | "invalid_provider";
+
+type ParseError = {
+  env: string;
+  message: string;
+  code: ParseErrorCode;
 };
 
-const parseBoolean = (input: string | undefined, defaultValue: boolean): boolean => {
+const parseErrors: ParseError[] = [];
+
+const addParseError = (env: string, message: string, code: ParseErrorCode): void => {
+  parseErrors.push({ env, message, code });
+};
+
+const parseModelMap = (input: string | undefined, env: string): Record<string, string> => {
+  return parseJsonMap(input, env);
+};
+
+const parseBoolean = (
+  input: string | undefined,
+  defaultValue: boolean,
+  env: string,
+): boolean => {
   if (input == null) return defaultValue;
   const normalized = input.trim().toLowerCase();
   if (["1", "true", "yes", "on"].includes(normalized)) return true;
   if (["0", "false", "no", "off"].includes(normalized)) return false;
+  addParseError(
+    env,
+    `expected boolean-like value (true/false/1/0/yes/no/on/off), got '${input}'`,
+    "invalid_boolean",
+  );
   return defaultValue;
 };
 
-const parseNumber = (input: string | undefined, defaultValue: number): number => {
+const parseNumber = (input: string | undefined, defaultValue: number, env: string): number => {
   if (!input) return defaultValue;
   const parsed = Number(input);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  addParseError(env, `expected a positive number, got '${input}'`, "invalid_number");
+  return defaultValue;
 };
 
-const parseNonNegativeInt = (input: string | undefined, defaultValue: number): number => {
+const parseNonNegativeInt = (
+  input: string | undefined,
+  defaultValue: number,
+  env: string,
+): number => {
   if (!input) return defaultValue;
   const parsed = Number.parseInt(input, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultValue;
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  addParseError(env, `expected a non-negative integer, got '${input}'`, "invalid_non_negative_int");
+  return defaultValue;
 };
 
 const normalizeBaseUrl = (input: string | undefined): string | null => {
@@ -34,87 +75,159 @@ const normalizeBaseUrl = (input: string | undefined): string | null => {
   return input.replace(/\/+$/, "");
 };
 
-type DownstreamAuthMode = "none" | "bearer" | "x-api-key" | "passthrough";
-type DownstreamMode = "openai-compatible" | "anthropic-sdk";
-
 const parseDownstreamAuthMode = (input: string | undefined): DownstreamAuthMode => {
   const normalized = input?.trim().toLowerCase();
 
+  if (normalized == null || normalized === "") return "bearer";
   if (normalized === "none") return "none";
   if (normalized === "x-api-key") return "x-api-key";
   if (normalized === "passthrough") return "passthrough";
+  if (normalized === "bearer") return "bearer";
+
+  addParseError(
+    "DOWNSTREAM_AUTH_MODE",
+    `expected one of none|bearer|x-api-key|passthrough, got '${input}'`,
+    "invalid_enum",
+  );
   return "bearer";
 };
 
 const parseDownstreamMode = (input: string | undefined): DownstreamMode => {
   const normalized = input?.trim().toLowerCase();
+  if (normalized == null || normalized === "") return "openai-compatible";
   if (normalized === "anthropic-sdk") return "anthropic-sdk";
+  if (normalized === "openai-compatible") return "openai-compatible";
+
+  addParseError(
+    "DOWNSTREAM_MODE",
+    `expected one of openai-compatible|anthropic-sdk, got '${input}'`,
+    "invalid_enum",
+  );
   return "openai-compatible";
 };
-
 
 const isRequestProtocol = (v: unknown): v is RequestProtocol =>
   v === "chat_completions" || v === "responses";
 
-const parseProtocols = (input: unknown, defaultValue: RequestProtocol[]): RequestProtocol[] => {
-  if (!Array.isArray(input)) return defaultValue;
+const parseProtocols = (
+  input: unknown,
+  defaultValue: RequestProtocol[],
+  env: string,
+): RequestProtocol[] => {
+  if (!Array.isArray(input)) {
+    addParseError(env, "expected an array of protocols", "invalid_json_type");
+    return defaultValue;
+  }
   const out = input.filter(isRequestProtocol);
-  return out.length > 0 ? out : defaultValue;
+  if (out.length === 0) {
+    addParseError(env, "must include at least one supported protocol", "invalid_provider");
+    return defaultValue;
+  }
+  if (out.length !== input.length) {
+    addParseError(
+      env,
+      "contains unsupported protocol(s); allowed values are chat_completions,responses",
+      "invalid_provider",
+    );
+  }
+  return out;
 };
 
-const parseProtocolsCsv = (input: string | undefined, defaultValue: RequestProtocol[]): RequestProtocol[] => {
+const parseProtocolsCsv = (
+  input: string | undefined,
+  defaultValue: RequestProtocol[],
+): RequestProtocol[] => {
   if (!input?.trim()) return defaultValue;
-  const out = input.split(",").map((s) => s.trim()).filter(isRequestProtocol);
-  return out.length > 0 ? out : defaultValue;
+  const tokens = input.split(",").map((s) => s.trim()).filter(Boolean);
+  const out = tokens.filter(isRequestProtocol);
+  if (out.length === 0) {
+    addParseError(
+      "DOWNSTREAM_PROTOCOLS",
+      `must include at least one supported protocol (chat_completions,responses), got '${input}'`,
+      "invalid_enum",
+    );
+    return defaultValue;
+  }
+  if (out.length !== tokens.length) {
+    addParseError(
+      "DOWNSTREAM_PROTOCOLS",
+      `contains unsupported protocol(s), got '${input}'`,
+      "invalid_enum",
+    );
+  }
+  return out;
 };
 
 const parseProviders = (input: string | undefined): ProviderConfig[] => {
   if (!input?.trim()) return [];
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(input);
-    if (!Array.isArray(parsed)) return [];
-    const out: ProviderConfig[] = [];
-    for (const raw of parsed) {
-      if (!raw || typeof raw !== "object") continue;
-      const r = raw as Record<string, unknown>;
-      if (typeof r.id !== "string" || !r.id.trim()) continue;
-      if (r.kind !== "openai-compatible" && r.kind !== "anthropic-sdk") continue;
-      const kind = r.kind as ProviderKind;
-      const models = Array.isArray(r.models)
-        ? (r.models as Array<Record<string, unknown>>)
-            .filter((m) => m && typeof m.id === "string")
-            .map((m) => ({
-              id: m.id as string,
-              costInputUsdPerMTok:
-                typeof m.costInputUsdPerMTok === "number" ? m.costInputUsdPerMTok : undefined,
-              costOutputUsdPerMTok:
-                typeof m.costOutputUsdPerMTok === "number" ? m.costOutputUsdPerMTok : undefined,
-            }))
-        : [];
-      const auth =
-        r.auth && typeof r.auth === "object"
-          ? (r.auth as ProviderConfig["auth"])
-          : ({ mode: "none" } as ProviderConfig["auth"]);
-      out.push({
-        id: r.id,
-        kind,
-        protocols: parseProtocols(r.protocols, ["chat_completions"]),
-        baseUrl:
-          typeof r.baseUrl === "string" ? normalizeBaseUrl(r.baseUrl) : null,
-        auth,
-        extraHeaders:
-          r.extraHeaders && typeof r.extraHeaders === "object"
-            ? (r.extraHeaders as Record<string, string>)
-            : undefined,
-        timeoutMs: typeof r.timeoutMs === "number" ? r.timeoutMs : undefined,
-        models,
-      });
-    }
-    return out;
+    parsed = JSON.parse(input);
   } catch {
-    // fall back to empty registry; caller synthesizes a legacy entry
+    addParseError("PROVIDERS", "must be valid JSON", "invalid_json");
     return [];
   }
+
+  if (!Array.isArray(parsed)) {
+    addParseError("PROVIDERS", "must be a JSON array", "invalid_json_type");
+    return [];
+  }
+
+  const out: ProviderConfig[] = [];
+  for (let i = 0; i < parsed.length; i += 1) {
+    const raw = parsed[i];
+    if (!raw || typeof raw !== "object") {
+      addParseError("PROVIDERS", `entry[${i}] must be an object`, "invalid_provider");
+      continue;
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r.id !== "string" || !r.id.trim()) {
+      addParseError("PROVIDERS", `entry[${i}].id must be a non-empty string`, "invalid_provider");
+      continue;
+    }
+    if (r.kind !== "openai-compatible" && r.kind !== "anthropic-sdk") {
+      addParseError(
+        "PROVIDERS",
+        `entry[${i}].kind must be 'openai-compatible' or 'anthropic-sdk'`,
+        "invalid_provider",
+      );
+      continue;
+    }
+    const kind = r.kind as ProviderKind;
+    const models = Array.isArray(r.models)
+      ? (r.models as Array<Record<string, unknown>>)
+          .filter((m) => m && typeof m.id === "string")
+          .map((m) => ({
+            id: m.id as string,
+            costInputUsdPerMTok:
+              typeof m.costInputUsdPerMTok === "number" ? m.costInputUsdPerMTok : undefined,
+            costOutputUsdPerMTok:
+              typeof m.costOutputUsdPerMTok === "number" ? m.costOutputUsdPerMTok : undefined,
+          }))
+      : [];
+    const auth =
+      r.auth && typeof r.auth === "object"
+        ? (r.auth as ProviderConfig["auth"])
+        : ({ mode: "none" } as ProviderConfig["auth"]);
+    out.push({
+      id: r.id,
+      kind,
+      protocols:
+        r.protocols === undefined
+          ? ["chat_completions"]
+          : parseProtocols(r.protocols, ["chat_completions"], `PROVIDERS[${i}].protocols`),
+      baseUrl: typeof r.baseUrl === "string" ? normalizeBaseUrl(r.baseUrl) : null,
+      auth,
+      extraHeaders:
+        r.extraHeaders && typeof r.extraHeaders === "object"
+          ? (r.extraHeaders as Record<string, string>)
+          : undefined,
+      timeoutMs: typeof r.timeoutMs === "number" ? r.timeoutMs : undefined,
+      models,
+    });
+  }
+  return out;
 };
 
 const toStringArray = (value: unknown): string[] | undefined => {
@@ -128,16 +241,20 @@ const parseRoutingRules = (input: string | undefined): RoutingRule[] => {
   if (!input?.trim()) return [];
   try {
     const parsed = JSON.parse(input);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      addParseError("ROUTING_RULES", "must be a JSON array", "invalid_json_type");
+      return [];
+    }
     const out: RoutingRule[] = [];
-    for (const raw of parsed) {
+    for (let i = 0; i < parsed.length; i += 1) {
+      const raw = parsed[i];
       if (!raw || typeof raw !== "object") continue;
       const r = raw as Record<string, unknown>;
       if (typeof r.id !== "string" || !r.id.trim()) continue;
       if (typeof r.resolvedModel !== "string" || !r.resolvedModel.trim()) continue;
       out.push({
         id: r.id.trim(),
-        protocols: parseProtocols(r.protocols, ["chat_completions"]),
+        protocols: parseProtocols(r.protocols, ["chat_completions"], `ROUTING_RULES[${i}].protocols`),
         runtime: Array.isArray(r.runtime) ? toStringArray(r.runtime) : typeof r.runtime === "string" ? r.runtime.trim() : undefined,
         requestedModel: Array.isArray(r.requestedModel)
           ? toStringArray(r.requestedModel)
@@ -152,26 +269,99 @@ const parseRoutingRules = (input: string | undefined): RoutingRule[] => {
     }
     return out;
   } catch {
+    addParseError("ROUTING_RULES", "must be valid JSON", "invalid_json");
     return [];
   }
 };
 
-const parseJsonMap = (input: string | undefined): Record<string, string> => {
+const parseJsonMap = (input: string | undefined, env: string): Record<string, string> => {
   if (!input) return {};
 
   try {
     const parsed = JSON.parse(input);
-    if (parsed && typeof parsed === "object") {
-      const entries = Object.entries(parsed).filter(
-        ([k, v]) => typeof k === "string" && typeof v === "string",
-      ) as Array<[string, string]>;
-      return Object.fromEntries(entries);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      addParseError(env, "must be a JSON object map", "invalid_json_type");
+      return {};
     }
+    const entries = Object.entries(parsed).filter(
+      ([k, v]) => typeof k === "string" && typeof v === "string",
+    ) as Array<[string, string]>;
+    if (entries.length !== Object.keys(parsed).length) {
+      addParseError(env, "all map values must be strings", "invalid_json_type");
+    }
+    return Object.fromEntries(entries);
   } catch {
-    // ignore invalid map and fall back to empty map
+    addParseError(env, "must be valid JSON", "invalid_json");
+    return {};
+  }
+};
+
+const buildStartupValidationErrors = (cfg: typeof config): string[] => {
+  const errors = parseErrors.map((e) => `${e.env}: ${e.message}`);
+
+  if (!Number.isFinite(cfg.port) || cfg.port <= 0 || cfg.port > 65535) {
+    errors.push(`PORT: expected a valid TCP port (1-65535), got '${process.env.PORT ?? ""}'`);
   }
 
-  return {};
+  if (cfg.downstreamMode === "openai-compatible") {
+    const hasProviders = cfg.providers.length > 0;
+    const hasLegacyOpenAiPath =
+      Boolean(cfg.downstreamBaseUrl) || cfg.downstreamMockFallbackEnabled;
+    if (!hasProviders && !hasLegacyOpenAiPath) {
+      errors.push(
+        "Config incomplete: DOWNSTREAM_MODE=openai-compatible requires one of: " +
+          "(a) PROVIDERS with at least one openai-compatible provider, or " +
+          "(b) DOWNSTREAM_BASE_URL set, or " +
+          "(c) DOWNSTREAM_MOCK_FALLBACK=true.",
+      );
+    }
+
+    if (cfg.downstreamAuthMode === "bearer" || cfg.downstreamAuthMode === "x-api-key") {
+      if (!cfg.downstreamApiKey?.trim()) {
+        errors.push(
+          `DOWNSTREAM_API_KEY is required when DOWNSTREAM_AUTH_MODE=${cfg.downstreamAuthMode}.`,
+        );
+      }
+    }
+  }
+
+  if (cfg.downstreamMode === "anthropic-sdk") {
+    const hasProviders = cfg.providers.length > 0;
+    const hasLegacyToken = Boolean(cfg.anthropicOauthToken?.trim() || cfg.anthropicApiKey?.trim());
+    if (!hasProviders && !hasLegacyToken) {
+      errors.push(
+        "Config incomplete: DOWNSTREAM_MODE=anthropic-sdk requires one of: " +
+          "(a) PROVIDERS with at least one anthropic-sdk provider, or " +
+          "(b) ANTHROPIC_OAUTH_TOKEN or ANTHROPIC_API_KEY.",
+      );
+    }
+  }
+
+  if (cfg.downstreamProtocols.includes("responses")) {
+    const providerProtocols = cfg.providers.flatMap((p) => p.protocols ?? ["chat_completions"]);
+    const globalDeclaresResponses = cfg.downstreamProtocols.includes("responses");
+    const anyProviderDeclaresResponses = providerProtocols.includes("responses");
+    if (cfg.providers.length > 0 && globalDeclaresResponses && !anyProviderDeclaresResponses) {
+      errors.push(
+        "DOWNSTREAM_PROTOCOLS includes 'responses' but no provider in PROVIDERS declares the 'responses' protocol. " +
+          "Add \"protocols\": [\"chat_completions\",\"responses\"] to a provider entry, or remove 'responses' from DOWNSTREAM_PROTOCOLS.",
+      );
+    }
+  }
+
+  return errors;
+};
+
+export const validateStartupConfig = (cfg: typeof config = config): void => {
+  const errors = buildStartupValidationErrors(cfg);
+  if (errors.length === 0) return;
+  throw new Error(
+    [
+      "Invalid startup configuration:",
+      ...errors.map((e) => `- ${e}`),
+      "Fix your environment variables (see .env.example) and restart.",
+    ].join("\n"),
+  );
 };
 
 export const config = {
@@ -180,8 +370,8 @@ export const config = {
   defaultProvider: process.env.DEFAULT_PROVIDER ?? "openai-compatible",
   defaultBackendTarget:
     process.env.DEFAULT_BACKEND_TARGET ?? "mock://downstream-chat-completions",
-  modelMap: parseModelMap(process.env.MODEL_MAP),
-  anthropicModelMap: parseModelMap(process.env.ANTHROPIC_MODEL_MAP),
+  modelMap: parseModelMap(process.env.MODEL_MAP, "MODEL_MAP"),
+  anthropicModelMap: parseModelMap(process.env.ANTHROPIC_MODEL_MAP, "ANTHROPIC_MODEL_MAP"),
   downstreamMode: parseDownstreamMode(process.env.DOWNSTREAM_MODE),
   downstreamBaseUrl: normalizeBaseUrl(process.env.DOWNSTREAM_BASE_URL),
   downstreamApiKey: process.env.DOWNSTREAM_API_KEY,
@@ -189,24 +379,26 @@ export const config = {
   anthropicBaseUrl: normalizeBaseUrl(process.env.ANTHROPIC_BASE_URL),
   anthropicApiKey: process.env.ANTHROPIC_API_KEY,
   anthropicOauthToken: process.env.ANTHROPIC_OAUTH_TOKEN,
-  downstreamTimeoutMs: parseNumber(process.env.DOWNSTREAM_TIMEOUT_MS, 30_000),
-  downstreamExtraHeaders: parseJsonMap(process.env.DOWNSTREAM_EXTRA_HEADERS),
+  downstreamTimeoutMs: parseNumber(process.env.DOWNSTREAM_TIMEOUT_MS, 30_000, "DOWNSTREAM_TIMEOUT_MS"),
+  downstreamExtraHeaders: parseJsonMap(process.env.DOWNSTREAM_EXTRA_HEADERS, "DOWNSTREAM_EXTRA_HEADERS"),
   downstreamProtocols: parseProtocolsCsv(process.env.DOWNSTREAM_PROTOCOLS, ["chat_completions"]),
   downstreamMockFallbackEnabled: parseBoolean(
     process.env.DOWNSTREAM_MOCK_FALLBACK,
     process.env.NODE_ENV !== "production",
+    "DOWNSTREAM_MOCK_FALLBACK",
   ),
   agentweaveOtlpEndpoint: process.env.AGENTWEAVE_OTLP_ENDPOINT || null,
   agentweaveAgentId: process.env.AGENTWEAVE_AGENT_ID || "mux-router",
   tracePromptPreviewEnabled: parseBoolean(
     process.env.TRACE_PROMPT_PREVIEW_ENABLED,
     process.env.NODE_ENV !== "production",
+    "TRACE_PROMPT_PREVIEW_ENABLED",
   ),
   tracePromptPreviewRedactedValue:
     process.env.TRACE_PROMPT_PREVIEW_REDACTED_VALUE || "[redacted]",
   providers: parseProviders(process.env.PROVIDERS),
   routingRules: parseRoutingRules(process.env.ROUTING_RULES),
-  failoverMaxAttempts: parseNonNegativeInt(process.env.FAILOVER_MAX_ATTEMPTS, 1),
+  failoverMaxAttempts: parseNonNegativeInt(process.env.FAILOVER_MAX_ATTEMPTS, 1, "FAILOVER_MAX_ATTEMPTS"),
   // Inject Anthropic ephemeral prompt-cache breakpoints in the OpenAI →
   // Anthropic translator (system prompt, tools, history). On by default —
   // correctly-formed requests only benefit. Opt out with
@@ -214,5 +406,7 @@ export const config = {
   anthropicPromptCacheEnabled: parseBoolean(
     process.env.MUX_ANTHROPIC_PROMPT_CACHE,
     true,
+    "MUX_ANTHROPIC_PROMPT_CACHE",
   ),
 };
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,8 @@
 import { createApp } from "./app.js";
-import { config } from "./config.js";
+import { config, validateStartupConfig } from "./config.js";
 import { initTracing } from "./tracing.js";
+
+validateStartupConfig(config);
 
 await initTracing();
 

--- a/tests/config.validation.test.ts
+++ b/tests/config.validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+type EnvMap = Record<string, string | undefined>;
+
+const validateWithEnv = async (env: EnvMap) => {
+  const previous = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(env)) {
+    previous.set(k, process.env[k]);
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+
+  try {
+    const nonce = `case-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const modPath = new URL(`../src/config.ts?${nonce}`, import.meta.url).href;
+    const mod = await import(modPath);
+    mod.validateStartupConfig(mod.config);
+    return mod;
+  } finally {
+    for (const [k, v] of previous.entries()) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  }
+};
+
+describe("startup config validation", () => {
+  it("fails fast when DOWNSTREAM_MODE is invalid", async () => {
+    await expect(
+      validateWithEnv({
+        PROVIDERS: "[]",
+        DOWNSTREAM_MODE: "bad-mode",
+        DOWNSTREAM_BASE_URL: "http://localhost:4000/v1",
+        DOWNSTREAM_AUTH_MODE: "none",
+      }),
+    ).rejects.toThrow(/DOWNSTREAM_MODE/);
+  });
+
+  it("fails fast when DOWNSTREAM_AUTH_MODE requires API key", async () => {
+    await expect(
+      validateWithEnv({
+        PROVIDERS: "[]",
+        DOWNSTREAM_MODE: "openai-compatible",
+        DOWNSTREAM_BASE_URL: "http://localhost:4000/v1",
+        DOWNSTREAM_AUTH_MODE: "bearer",
+        DOWNSTREAM_API_KEY: "",
+      }),
+    ).rejects.toThrow(/DOWNSTREAM_API_KEY is required/);
+  });
+
+  it("fails fast on invalid JSON map", async () => {
+    await expect(
+      validateWithEnv({
+        PROVIDERS: "[]",
+        DOWNSTREAM_MODE: "openai-compatible",
+        DOWNSTREAM_BASE_URL: "http://localhost:4000/v1",
+        DOWNSTREAM_AUTH_MODE: "none",
+        MODEL_MAP: "{not-json}",
+      }),
+    ).rejects.toThrow(/MODEL_MAP/);
+  });
+
+  it("fails fast when anthropic-sdk has no providers and no token", async () => {
+    await expect(
+      validateWithEnv({
+        PROVIDERS: "[]",
+        DOWNSTREAM_MODE: "anthropic-sdk",
+        ANTHROPIC_OAUTH_TOKEN: "",
+        ANTHROPIC_API_KEY: "",
+      }),
+    ).rejects.toThrow(/DOWNSTREAM_MODE=anthropic-sdk/);
+  });
+
+  it("fails fast when 'responses' is declared globally but no provider exposes it", async () => {
+    await expect(
+      validateWithEnv({
+        DOWNSTREAM_MODE: "openai-compatible",
+        DOWNSTREAM_AUTH_MODE: "none",
+        DOWNSTREAM_PROTOCOLS: "chat_completions,responses",
+        PROVIDERS: JSON.stringify([
+          {
+            id: "default",
+            kind: "openai-compatible",
+            baseUrl: "http://localhost:4000/v1",
+            auth: { mode: "none" },
+            protocols: ["chat_completions"],
+            models: [{ id: "gpt-4o-mini" }],
+          },
+        ]),
+      }),
+    ).rejects.toThrow(/responses/);
+  });
+});


### PR DESCRIPTION
## Summary
- fail fast on invalid or incomplete startup config
- tighten dotenv example formatting so it can be copied directly
- add focused validation tests for common bad configs

## Why
Mux is infrastructure glue, so silent config drift is worse than a loud startup failure. This makes bad configuration fail early with actionable messages.

## Testing
- `npm test -- --run tests/config.validation.test.ts`
