### PR TITLE
fix: make prompt preview tracing safe by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,9 +63,11 @@ FAILOVER_MAX_ATTEMPTS=1
 # Tempo OTLP HTTP endpoint. On the NAS, Tempo listens on localhost:4318.
 AGENTWEAVE_OTLP_ENDPOINT=http://localhost:4318/v1/traces
 AGENTWEAVE_AGENT_ID=mux-router
-# Prompt preview tracing controls. Defaults to true outside production, false in production.
-# When disabled, Mux writes TRACE_PROMPT_PREVIEW_REDACTED_VALUE instead of prompt text.
-TRACE_PROMPT_PREVIEW_ENABLED=true
+# Prompt preview tracing controls.
+# Safe-by-default: keep disabled unless you explicitly need preview text in traces.
+# When enabled, Mux applies best-effort redaction for common secrets (emails,
+# bearer tokens, common API key formats, and sensitive URL query params).
+TRACE_PROMPT_PREVIEW_ENABLED=false
 TRACE_PROMPT_PREVIEW_REDACTED_VALUE=[redacted]
 
 # Multi-provider routing (#39 Phase 1)

--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ FAILOVER_MAX_ATTEMPTS=1
 # Tempo OTLP HTTP endpoint. On the NAS, Tempo listens on localhost:4318.
 AGENTWEAVE_OTLP_ENDPOINT=http://localhost:4318/v1/traces
 AGENTWEAVE_AGENT_ID=mux-router
+# Prompt preview tracing controls. Defaults to true outside production, false in production.
+# When disabled, Mux writes TRACE_PROMPT_PREVIEW_REDACTED_VALUE instead of prompt text.
+TRACE_PROMPT_PREVIEW_ENABLED=true
+TRACE_PROMPT_PREVIEW_REDACTED_VALUE=[redacted]
 
 # Multi-provider routing (#39 Phase 1)
 # ---

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ curl -s http://localhost:8787/v1/responses \
 | `ANTHROPIC_API_KEY` | — | API key fallback for anthropic-sdk |
 | `ANTHROPIC_BASE_URL` | — | Override Anthropic API URL (supports proxies) |
 | `MUX_ANTHROPIC_PROMPT_CACHE` | `true` | Inject Anthropic ephemeral `cache_control` breakpoints on the translated request (system, tools, history) |
-| `TRACE_PROMPT_PREVIEW_ENABLED` | `true` (dev), `false` (prod) | Enable prompt preview text on tracing span attrs |
+| `TRACE_PROMPT_PREVIEW_ENABLED` | `false` | Enable prompt preview text on tracing span attrs (opt-in; disabled by default for safety) |
 | `TRACE_PROMPT_PREVIEW_REDACTED_VALUE` | `[redacted]` | Value written to trace attrs when prompt preview tracing is disabled |
 
 ## Prompt caching (Anthropic)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ curl -s http://localhost:8787/v1/responses \
 | `ANTHROPIC_API_KEY` | — | API key fallback for anthropic-sdk |
 | `ANTHROPIC_BASE_URL` | — | Override Anthropic API URL (supports proxies) |
 | `MUX_ANTHROPIC_PROMPT_CACHE` | `true` | Inject Anthropic ephemeral `cache_control` breakpoints on the translated request (system, tools, history) |
+| `TRACE_PROMPT_PREVIEW_ENABLED` | `true` (dev), `false` (prod) | Enable prompt preview text on tracing span attrs |
+| `TRACE_PROMPT_PREVIEW_REDACTED_VALUE` | `[redacted]` | Value written to trace attrs when prompt preview tracing is disabled |
 
 ## Prompt caching (Anthropic)
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -96,6 +96,10 @@ const logRouteDecision = (params: {
   inputItemCount?: number;
 }) => {
   const { protocol, runtime, route, callerAgentId, promptPreview, messageCount, inputItemCount } = params;
+  const tracedPromptPreview = config.tracePromptPreviewEnabled
+    ? promptPreview
+    : config.tracePromptPreviewRedactedValue;
+
   setSpanAttrs({
     "prov.route.protocol": protocol,
     "prov.route.requested_model": route.requestedModel,
@@ -104,7 +108,7 @@ const logRouteDecision = (params: {
     "prov.route.runtime": runtime,
     "prov.route.provider_id": route.providerId,
     "prov.llm.model": route.resolvedModel,
-    "prov.llm.prompt_preview": promptPreview,
+    "prov.llm.prompt_preview": tracedPromptPreview,
     ...(typeof messageCount === "number" ? { "prov.route.message_count": messageCount } : {}),
     ...(typeof inputItemCount === "number" ? { "prov.route.input_item_count": inputItemCount } : {}),
     ...(callerAgentId ? { "prov.agent.id": callerAgentId } : {}),

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,6 +57,24 @@ const extractTextFromUnknown = (value: unknown): string[] => {
   return out;
 };
 
+const redactPromptPreview = (value: string): string => {
+  if (!value) return value;
+
+  return value
+    // email addresses
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[redacted-email]")
+    // bearer tokens
+    .replace(/\bbearer\s+[a-z0-9._~+/=-]+\b/gi, "Bearer [redacted-token]")
+    // common api key formats (OpenAI, Anthropic, GitHub, Google, AWS)
+    .replace(/\b(sk-[a-z0-9_-]{16,}|sk-ant-[a-z0-9_-]{16,}|ghp_[a-z0-9]{20,}|AIza[a-z0-9_-]{20,}|AKIA[0-9A-Z]{16})\b/g, "[redacted-api-key]")
+    // key/value secret-ish fields
+    .replace(/\b(token|secret|password|api[_-]?key|access[_-]?token|refresh[_-]?token)\s*[:=]\s*([^\s,;]+)/gi, "$1=[redacted]")
+    // urls with sensitive query params
+    .replace(/https?:\/\/[^\s)]+/gi, (url) =>
+      url.replace(/([?&](?:token|access_token|auth|key|api_key|secret|sig|signature|password)=)[^&#\s]*/gi, "$1[redacted]"),
+    );
+};
+
 const buildPromptPreviewForChat = (messages: ChatMessage[]): string => {
   const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
   if (!lastUserMsg) return "";
@@ -97,7 +115,7 @@ const logRouteDecision = (params: {
 }) => {
   const { protocol, runtime, route, callerAgentId, promptPreview, messageCount, inputItemCount } = params;
   const tracedPromptPreview = config.tracePromptPreviewEnabled
-    ? promptPreview
+    ? redactPromptPreview(promptPreview)
     : config.tracePromptPreviewRedactedValue;
 
   setSpanAttrs({

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,12 @@ export const config = {
   ),
   agentweaveOtlpEndpoint: process.env.AGENTWEAVE_OTLP_ENDPOINT || null,
   agentweaveAgentId: process.env.AGENTWEAVE_AGENT_ID || "mux-router",
+  tracePromptPreviewEnabled: parseBoolean(
+    process.env.TRACE_PROMPT_PREVIEW_ENABLED,
+    process.env.NODE_ENV !== "production",
+  ),
+  tracePromptPreviewRedactedValue:
+    process.env.TRACE_PROMPT_PREVIEW_REDACTED_VALUE || "[redacted]",
   providers: parseProviders(process.env.PROVIDERS),
   failoverMaxAttempts: parseNonNegativeInt(process.env.FAILOVER_MAX_ATTEMPTS, 1),
   // Inject Anthropic ephemeral prompt-cache breakpoints in the OpenAI →

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -78,7 +78,7 @@ describe("createApp", () => {
     expect(res.body.choices?.[0]?.message?.content).toContain("resolved=gpt-4o-mini");
   });
 
-  it("redacts prompt preview span attr by default in production", async () => {
+  it("redacts prompt preview span attr by default when disabled", async () => {
     const previousNodeEnv = config.nodeEnv;
     const previousTracePreview = config.tracePromptPreviewEnabled;
     const previousRedactedValue = config.tracePromptPreviewRedactedValue;
@@ -110,6 +110,44 @@ describe("createApp", () => {
     config.nodeEnv = previousNodeEnv;
     config.tracePromptPreviewEnabled = previousTracePreview;
     config.tracePromptPreviewRedactedValue = previousRedactedValue;
+  });
+
+  it("sanitizes prompt preview when explicitly enabled", async () => {
+    const previousTracePreview = config.tracePromptPreviewEnabled;
+    config.tracePromptPreviewEnabled = true;
+
+    const tracing = await import("../src/tracing.js");
+    const spanSpy = vi.spyOn(tracing, "setSpanAttrs");
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4o",
+        messages: [
+          {
+            role: "user",
+            content:
+              "email alice@example.com bearer sk-secretvalue1234567890123456 token=abc123 https://example.com/cb?access_token=xyz",
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    const calls = spanSpy.mock.calls.map((c) => c[0]);
+    const previewAttr = calls.find(
+      (attrs) => attrs && typeof attrs === "object" && "prov.llm.prompt_preview" in (attrs as Record<string, unknown>),
+    ) as Record<string, unknown> | undefined;
+
+    expect(typeof previewAttr?.["prov.llm.prompt_preview"]).toBe("string");
+    const preview = String(previewAttr?.["prov.llm.prompt_preview"] ?? "");
+    expect(preview).toContain("[redacted-email]");
+    expect(preview).toContain("Bearer [redacted-token]");
+    expect(preview).toContain("token=[redacted]");
+    expect(preview).toContain("access_token=[redacted]");
+    expect(preview).not.toContain("alice@example.com");
+    expect(preview).not.toContain("sk-secretvalue");
+
+    config.tracePromptPreviewEnabled = previousTracePreview;
   });
 
   it("returns OpenAI-compatible SSE chunks when stream=true", async () => {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,5 +1,5 @@
 import request from "supertest";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../src/app.js";
 import { config } from "../src/config.js";
@@ -76,6 +76,40 @@ describe("createApp", () => {
     expect(res.body.model).toBe("gpt-4o-mini");
     expect(res.body.choices?.[0]?.message?.content).toContain("requested=gpt-4o");
     expect(res.body.choices?.[0]?.message?.content).toContain("resolved=gpt-4o-mini");
+  });
+
+  it("redacts prompt preview span attr by default in production", async () => {
+    const previousNodeEnv = config.nodeEnv;
+    const previousTracePreview = config.tracePromptPreviewEnabled;
+    const previousRedactedValue = config.tracePromptPreviewRedactedValue;
+
+    config.nodeEnv = "production";
+    config.tracePromptPreviewEnabled = false;
+    config.tracePromptPreviewRedactedValue = "[redacted]";
+
+    const tracing = await import("../src/tracing.js");
+    const spanSpy = vi.spyOn(tracing, "setSpanAttrs");
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "super secret prompt" }],
+      });
+
+    expect(res.status).toBe(200);
+    const calls = spanSpy.mock.calls.map((c) => c[0]);
+    const hasRedactedPreview = calls.some(
+      (attrs) =>
+        attrs &&
+        typeof attrs === "object" &&
+        (attrs as Record<string, unknown>)["prov.llm.prompt_preview"] === "[redacted]",
+    );
+    expect(hasRedactedPreview).toBe(true);
+
+    config.nodeEnv = previousNodeEnv;
+    config.tracePromptPreviewEnabled = previousTracePreview;
+    config.tracePromptPreviewRedactedValue = previousRedactedValue;
   });
 
   it("returns OpenAI-compatible SSE chunks when stream=true", async () => {


### PR DESCRIPTION
## Summary
- disable prompt preview tracing by default
- add best-effort redaction when previews are explicitly enabled
- document the opt-in env knobs and add coverage for redaction behavior

## Why
Prompt previews are useful for debugging, but emitting raw prompt text by default is too risky for real traffic. This makes the safer behavior the default while keeping an escape hatch for intentional debugging.

## Testing
- `npm test -- --run tests/app.test.ts`
