### PR TITLE
feat: add readiness endpoint for provider health

### DIFF
--- a/docs/deploy-debian.md
+++ b/docs/deploy-debian.md
@@ -85,7 +85,8 @@ systemctl --user status  mux.service --no-pager
 journalctl --user -u mux.service -n 30 --no-pager
 
 # Smoke
-curl -s http://localhost:8787/health
+curl -s http://localhost:8787/health   # liveness
+curl -s http://localhost:8787/ready    # readiness + provider diagnostics
 ```
 
 > **Drift caveat:** `package-lock.json` sometimes accumulates `peer: true`
@@ -199,6 +200,7 @@ WantedBy=multi-user.target
 sudo systemctl daemon-reload
 sudo systemctl enable --now mux.service
 curl -s http://localhost:8787/health
+curl -s http://localhost:8787/ready
 ```
 
 ---

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import pino from "pino";
 
 import { config } from "./config.js";
+import { listProviders } from "./providers/registry.js";
 import {
   callDownstream,
   callResponsesDownstream,
@@ -188,6 +189,43 @@ export const createApp = () => {
 
   app.get("/health", (_req, res) => {
     res.json({ ok: true, service: "mux", env: config.nodeEnv });
+  });
+
+  app.get("/ready", (_req, res) => {
+    const providers = listProviders();
+    const diagnostics = providers.map((provider) => ({
+      id: provider.id,
+      kind: provider.kind,
+      protocols: provider.protocols,
+      modelCount: provider.models.length,
+      hasResponses: provider.protocols.includes("responses"),
+    }));
+
+    const problems: string[] = [];
+    if (providers.length === 0) {
+      problems.push("no providers are registered");
+    }
+
+    const hasChatCapableProvider = providers.some((provider) =>
+      provider.protocols.includes("chat_completions"),
+    );
+    if (!hasChatCapableProvider) {
+      problems.push("no provider supports chat_completions");
+    }
+
+    const ready = problems.length === 0;
+    const status = ready ? 200 : 503;
+
+    res.status(status).json({
+      ok: ready,
+      service: "mux",
+      env: config.nodeEnv,
+      providerCount: providers.length,
+      diagnostics: {
+        providers: diagnostics,
+      },
+      ...(ready ? {} : { reasons: problems }),
+    });
   });
 
   app.post("/v1/chat/completions", async (req, res) => {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -25,6 +25,43 @@ describe("createApp", () => {
     });
   });
 
+  it("returns readiness with safe provider diagnostics", async () => {
+    const res = await request(app).get("/ready");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      service: "mux",
+      providerCount: 1,
+    });
+    expect(Array.isArray(res.body.diagnostics?.providers)).toBe(true);
+    expect(res.body.diagnostics.providers[0]).toMatchObject({
+      id: "default",
+      kind: "openai-compatible",
+    });
+    expect(JSON.stringify(res.body)).not.toContain("apiKey");
+    expect(JSON.stringify(res.body)).not.toContain("authorization");
+  });
+
+  it("returns 503 readiness when mux cannot route traffic", async () => {
+    const previousBaseUrl = config.downstreamBaseUrl;
+    const previousFallback = config.downstreamMockFallbackEnabled;
+
+    config.downstreamBaseUrl = null;
+    config.downstreamMockFallbackEnabled = false;
+    __resetProviderRegistryForTests();
+
+    const res = await request(app).get("/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.reasons).toContain("no providers are registered");
+
+    config.downstreamBaseUrl = previousBaseUrl;
+    config.downstreamMockFallbackEnabled = previousFallback;
+    __resetProviderRegistryForTests();
+  });
+
   it("rejects invalid chat completions payloads", async () => {
     const res = await request(app).post("/v1/chat/completions").send({ messages: [] });
 


### PR DESCRIPTION
## Summary
- add a dedicated `/ready` endpoint alongside `/health`
- return safe provider diagnostics and readiness reasons
- document the liveness vs readiness distinction in deploy docs

## Why
`/health` only proves the process is up. For mux, operators also need a readiness signal that tells them whether the configured providers can actually serve traffic.

## Testing
- `npm test -- --run tests/app.test.ts`
