### PR TITLE
chore(#47/#48): retry classification, missing failover tests, type-check tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.73.0",

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -155,10 +155,26 @@ export class DownstreamRequestError extends Error {
   }
 }
 
+// Network-layer error codes that undici/Node bubble up via `err.cause.code` on
+// a `TypeError("fetch failed", { cause })`. These are transient connection
+// failures where retrying against a different provider can plausibly succeed.
+const RETRYABLE_CAUSE_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "EPIPE",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
 // Decide whether a downstream failure should trigger cross-provider failover.
 // Retryable: 408/429/5xx from DownstreamRequestError, 401/403 (auth may differ
 // per provider), and network-layer errors (AbortError from our timeout or
-// "fetch failed" from Node's fetch). Non-retryable: 4xx client errors (400,
+// transient connection failures). Non-retryable: 4xx client errors (400,
 // 404, 422) — the request is malformed and won't improve on another provider.
 export const isRetryableDownstreamError = (err: unknown): boolean => {
   if (err instanceof DownstreamRequestError) {
@@ -170,6 +186,13 @@ export const isRetryableDownstreamError = (err: unknown): boolean => {
   }
   if (err instanceof Error) {
     if (err.name === "AbortError") return true;
+    // Authoritative: undici wraps the real network error under `err.cause.code`.
+    const cause = (err as { cause?: { code?: unknown } }).cause;
+    if (cause && typeof cause.code === "string" && RETRYABLE_CAUSE_CODES.has(cause.code)) {
+      return true;
+    }
+    // Fallback: Node 18+ wraps these as TypeError("fetch failed"). Kept for
+    // resilience against future runtime changes that drop `cause.code`.
     if (err.message.toLowerCase().includes("fetch failed")) return true;
   }
   return false;
@@ -711,6 +734,16 @@ const buildProviderChain = (route: RouteDecision): string[] => {
   return [primary, ...fallbacks.slice(0, hops)];
 };
 
+const describeFailoverError = (err: unknown): string => {
+  if (err instanceof DownstreamRequestError) return `status=${err.status}`;
+  if (err instanceof Error) {
+    const cause = (err as { cause?: { code?: unknown } }).cause;
+    if (cause && typeof cause.code === "string") return `${err.name}:${cause.code}`;
+    return err.name;
+  }
+  return "unknown";
+};
+
 const annotateFailoverHop = (
   i: number,
   id: string,
@@ -723,17 +756,17 @@ const annotateFailoverHop = (
     "prov.failover.active_provider": id,
     "prov.route.provider_id": id,
   });
+  const fromId = failedProviders[failedProviders.length - 1];
+  const fromUrl = fromId ? config.providers.find((p) => p.id === fromId)?.baseUrl ?? null : null;
+  const toUrl = config.providers.find((p) => p.id === id)?.baseUrl ?? null;
   downstreamLogger.warn({
     event: "mux.failover_hop",
-    from: failedProviders[failedProviders.length - 1],
+    from: fromId,
+    fromUrl,
     to: id,
+    toUrl,
     attempt: i,
-    reason:
-      lastError instanceof DownstreamRequestError
-        ? `status=${lastError.status}`
-        : lastError instanceof Error
-          ? lastError.name
-          : "unknown",
+    reason: describeFailoverError(lastError),
   });
 };
 

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -8,6 +8,7 @@ import {
   DownstreamRequestError,
   anthropicStopReasonToOpenAI,
   downstreamLogger,
+  isRetryableDownstreamError,
   streamAnthropicToOpenAI,
   streamDownstream,
   toAnthropicInput,
@@ -28,6 +29,8 @@ const route: RouteDecision = {
   routeReason: "heuristic:test",
   provider: "openai-compatible",
   backendTarget: "http://localhost:4000/v1",
+  providerId: "default",
+  fallbackProviderIds: [],
 };
 
 afterEach(() => {
@@ -2508,5 +2511,248 @@ describe("toOpenAIResponse — cache usage surfacing", () => {
     expect(
       (response.usage as { prompt_tokens_details?: unknown }).prompt_tokens_details,
     ).toBeUndefined();
+  });
+});
+
+// --- issue #47 follow-ups: retry classification + chain-order + headers-sent --
+
+describe("isRetryableDownstreamError — cause.code classification", () => {
+  const fetchFailedWithCause = (code: string): TypeError =>
+    new TypeError("fetch failed", {
+      cause: Object.assign(new Error("connect"), { code }),
+    });
+
+  it.each([
+    ["ECONNREFUSED"],
+    ["ECONNRESET"],
+    ["ENOTFOUND"],
+    ["EAI_AGAIN"],
+    ["ETIMEDOUT"],
+    ["UND_ERR_SOCKET"],
+  ])("classifies cause.code=%s as retryable", (code) => {
+    expect(isRetryableDownstreamError(fetchFailedWithCause(code))).toBe(true);
+  });
+
+  it("does not classify an unknown cause.code as retryable on its own merits", () => {
+    // The "fetch failed" message fallback still fires here, which is the
+    // intended behavior — the cause-code path is authoritative for known
+    // codes, the message fallback covers the rest.
+    const err = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("x"), { code: "UNEXPECTED_CODE" }),
+    });
+    expect(isRetryableDownstreamError(err)).toBe(true);
+  });
+
+  it("does not retry on plain non-network errors", () => {
+    expect(isRetryableDownstreamError(new Error("application bug"))).toBe(false);
+  });
+
+  it("retries on AbortError (timeout)", () => {
+    const err = new Error("timeout");
+    err.name = "AbortError";
+    expect(isRetryableDownstreamError(err)).toBe(true);
+  });
+});
+
+describe("callDownstream — chain order across 3 providers", () => {
+  const threeProviderRoute: RouteDecision = {
+    requestedModel: "gpt-4o",
+    resolvedModel: "gpt-4o-mini",
+    routeReason: "heuristic:test+cost_weighted",
+    provider: "openai-compatible",
+    backendTarget: "http://a/v1",
+    providerId: "a",
+    fallbackProviderIds: ["b", "c"],
+  };
+
+  const setupThreeProviders = () => {
+    const previousProviders = config.providers;
+    const previousAttempts = config.failoverMaxAttempts;
+    config.providers = [
+      {
+        id: "a", kind: "openai-compatible", baseUrl: "http://a/v1",
+        auth: { mode: "bearer", apiKey: "k-a" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.1, costOutputUsdPerMTok: 0.4 }],
+      },
+      {
+        id: "b", kind: "openai-compatible", baseUrl: "http://b/v1",
+        auth: { mode: "bearer", apiKey: "k-b" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.2, costOutputUsdPerMTok: 0.5 }],
+      },
+      {
+        id: "c", kind: "openai-compatible", baseUrl: "http://c/v1",
+        auth: { mode: "bearer", apiKey: "k-c" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.3, costOutputUsdPerMTok: 0.6 }],
+      },
+    ];
+    config.failoverMaxAttempts = 2;
+    __resetAnthropicClientForTests();
+    return () => {
+      config.providers = previousProviders;
+      config.failoverMaxAttempts = previousAttempts;
+      __resetAnthropicClientForTests();
+    };
+  };
+
+  it("walks a→b→c and succeeds on c when a and b error", async () => {
+    const restore = setupThreeProviders();
+    try {
+      const callOrder: string[] = [];
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.startsWith("http://a/")) {
+            callOrder.push("a");
+            return new Response("x", { status: 503 });
+          }
+          if (url.startsWith("http://b/")) {
+            callOrder.push("b");
+            return new Response("y", { status: 502 });
+          }
+          if (url.startsWith("http://c/")) {
+            callOrder.push("c");
+            return new Response(
+              JSON.stringify({
+                id: "x", object: "chat.completion", created: 1, model: "gpt-4o-mini",
+                choices: [{ index: 0, message: { role: "assistant", content: "from-c" }, finish_reason: "stop" }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }
+          throw new Error(`unexpected url: ${url}`);
+        });
+
+      const result = await callDownstream(requestPayload, threeProviderRoute);
+      expect(callOrder).toEqual(["a", "b", "c"]);
+      expect(result.choices[0]?.message.content).toBe("from-c");
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("streamDownstream — headers-sent guard with retryable mid-stream error", () => {
+  const streamRoute: RouteDecision = {
+    requestedModel: "gpt-4o",
+    resolvedModel: "gpt-4o-mini",
+    routeReason: "heuristic:test+cost_weighted",
+    provider: "openai-compatible",
+    backendTarget: "http://a/v1",
+    providerId: "a",
+    fallbackProviderIds: ["b"],
+  };
+
+  const setupTwoProviders = () => {
+    const previousProviders = config.providers;
+    const previousAttempts = config.failoverMaxAttempts;
+    config.providers = [
+      {
+        id: "a", kind: "openai-compatible", baseUrl: "http://a/v1",
+        auth: { mode: "bearer", apiKey: "k-a" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.1, costOutputUsdPerMTok: 0.4 }],
+      },
+      {
+        id: "b", kind: "openai-compatible", baseUrl: "http://b/v1",
+        auth: { mode: "bearer", apiKey: "k-b" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.2, costOutputUsdPerMTok: 0.5 }],
+      },
+    ];
+    config.failoverMaxAttempts = 1;
+    __resetAnthropicClientForTests();
+    return () => {
+      config.providers = previousProviders;
+      config.failoverMaxAttempts = previousAttempts;
+      __resetAnthropicClientForTests();
+    };
+  };
+
+  const makeStreamRes = () => {
+    const res = {
+      statusCode: 0,
+      headersSent: false,
+      headers: {} as Record<string, string>,
+      writes: [] as string[],
+      ended: false,
+      _listeners: {} as Record<string, Array<() => void>>,
+      status(code: number) { res.statusCode = code; return res; },
+      setHeader(k: string, v: string) { res.headers[k] = v; },
+      getHeader(k: string) { return res.headers[k]; },
+      write(chunk: string) { res.headersSent = true; res.writes.push(chunk); return true; },
+      end() { res.ended = true; },
+      once(event: string, cb: () => void) { (res._listeners[event] ||= []).push(cb); },
+      off(event: string, cb: () => void) {
+        const list = res._listeners[event];
+        if (!list) return;
+        const i = list.indexOf(cb);
+        if (i >= 0) list.splice(i, 1);
+      },
+      emit(event: string) { for (const cb of res._listeners[event] ?? []) cb(); },
+    };
+    return res;
+  };
+
+  it("does NOT failover after bytes have been written, even on a retryable error", async () => {
+    // Once the response writer has flushed any bytes, restarting against
+    // provider B would corrupt the SSE stream (mixed framing, duplicate
+    // [DONE], etc.). The headers-sent guard must block failover regardless
+    // of error retryability.
+    const restore = setupTwoProviders();
+    try {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.startsWith("http://a/")) {
+            // Emit one valid SSE frame, then a retryable network-class error.
+            const encoder = new TextEncoder();
+            const stream = new ReadableStream({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({
+                      id: "c", object: "chat.completion.chunk", created: 1, model: "gpt-4o-mini",
+                      choices: [{ index: 0, delta: { role: "assistant", content: "partial-from-a" }, finish_reason: null }],
+                    })}\n\n`,
+                  ),
+                );
+              },
+              pull(controller) {
+                controller.error(
+                  new TypeError("fetch failed", {
+                    cause: Object.assign(new Error("conn reset"), { code: "ECONNRESET" }),
+                  }),
+                );
+              },
+            });
+            return new Response(stream, {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            });
+          }
+          throw new Error("provider b must not be called once headers are sent");
+        });
+
+      const res = makeStreamRes();
+      await expect(
+        streamDownstream(
+          { ...requestPayload, stream: true },
+          streamRoute,
+          res as unknown as import("express").Response,
+        ),
+      ).rejects.toBeTruthy();
+
+      // Provider A streamed a frame (headersSent flipped); provider B was
+      // never contacted because the guard short-circuited even though the
+      // error was, on its own, retryable.
+      expect(res.headersSent).toBe(true);
+      expect(res.writes.join("")).toContain("partial-from-a");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/^http:\/\/a\//);
+    } finally {
+      restore();
+    }
   });
 });

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -251,6 +251,7 @@ describe("resolveRoute", () => {
       {
         id: "expensive",
         kind: "anthropic-sdk" as const,
+        protocols: ["chat_completions" as const],
         models: [
           { id: "claude-sonnet-4-6", costInputUsdPerMTok: 3, costOutputUsdPerMTok: 15 },
         ],
@@ -260,6 +261,7 @@ describe("resolveRoute", () => {
       {
         id: "cheap",
         kind: "openai-compatible" as const,
+        protocols: ["chat_completions" as const],
         models: [
           { id: "claude-sonnet-4-6", costInputUsdPerMTok: 2, costOutputUsdPerMTok: 10 },
         ],
@@ -297,6 +299,7 @@ describe("resolveRoute", () => {
       {
         id: "only-one",
         kind: "anthropic-sdk" as const,
+        protocols: ["chat_completions" as const],
         models: [{ id: "claude-sonnet-4-6" }],
         call: async () => ({} as any),
         stream: async () => {},

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #47 and #48 in one PR (both touch the same testing/observability surface area introduced by #45/#46).

### #47 — failover follow-ups
- **Retry classification**: `isRetryableDownstreamError` now consults `err.cause.code` authoritatively (undici wraps the real network error there) for `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `EAI_AGAIN`, `ETIMEDOUT`, `EPIPE`, and `UND_ERR_*`. The `"fetch failed"` message-substring check is kept as a fallback so we don't regress current behavior if Node ever stops attaching `cause`.
- **Three new tests**:
  - parameterized `cause.code` classification (6 codes + AbortError + plain non-network error)
  - 3-provider chain-order: `a → b → c`, primary and first fallback error, third succeeds, asserts call order
  - streaming headers-sent guard with a *retryable* mid-stream error: provider A streams a frame (flips `headersSent`), then errors with `ECONNRESET`; dispatcher must not failover (would corrupt SSE), provider B is never called
- **Enriched `mux.failover_hop` log**: now includes `fromUrl`/`toUrl` (looked up from `config.providers`) and a `reason` field that surfaces `cause.code` on network errors (e.g. `TypeError:ECONNRESET`)

### #48 — type-check tests
- `tsconfig.test.json` extends the base config with `tests/**/*.ts` included
- `npm run check` now runs `tsc --noEmit` against both `tsconfig.json` and `tsconfig.test.json`
- Fixed the drift this surfaced: shared `route` fixture in `tests/downstream.test.ts` was missing `providerId`/`fallbackProviderIds`, and provider mocks in `tests/policy.test.ts` were missing `protocols`

## Deferred from #47
**Item 3** (rename `prov.route.provider_id` → `prov.effective.provider_id` to keep the original route decision immutable) intentionally NOT in this PR — needs coordination with the AgentWeave Routing tab (arniesaha/agentweave#164) before flipping the schema.

## Testing
- `npm test` → 118/118 (was 107)
- `npm run check` → clean (src + tests)