### PR TITLE
feat: e2e suite + compatibility matrix (issue #60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,11 @@ jobs:
       - name: Typecheck
         run: npm run check
 
-      - name: Run tests
+      - name: Run unit tests
         run: npm test
+
+      - name: Run e2e tests
+        run: npm run test:e2e
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -228,10 +228,22 @@ session.
 
 **Opt out.** Set `MUX_ANTHROPIC_PROMPT_CACHE=false` to disable.
 
+## Compatibility
+
+See [docs/compatibility.md](docs/compatibility.md) for the full matrix of
+(provider kind × protocol × feature) combinations and which are
+"supported + tested" vs "supported + untested" vs "intentionally unsupported".
+The matrix is the source of truth for what mux actually validates end-to-end —
+unit tests are dense, but the e2e suite under `tests/e2e/` is the gate that
+asserts each public endpoint shape against `createApp()` with mocked
+downstreams.
+
 ## Running tests
 
 ```bash
-npm test
+npm test          # unit suite (fast, hermetic)
+npm run test:e2e  # end-to-end suite (in-process supertest against createApp)
+npm run test:all  # both
 ```
 
 ## Architecture diagrams

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,47 @@
+# Compatibility matrix
+
+This document tracks which (provider kind × protocol × feature) combinations are
+exercised by automated tests, which are merely intended to work, and which are
+known gaps. A combination is only marked "supported + tested" when at least one
+e2e test under `tests/e2e/` drives it through `createApp()` end-to-end.
+
+Status legend:
+
+- supported + tested — at least one e2e or integration test asserts the contract
+- supported + untested — code path exists but no e2e coverage; relies on unit tests only
+- intentionally unsupported — out of scope by design
+- broken / known-gap — known not to work, tracked as an issue
+
+| Provider kind        | Protocol           | Feature                                                | Status                  | Notes |
+| -------------------- | ------------------ | ------------------------------------------------------ | ----------------------- | ----- |
+| openai-compatible    | chat_completions   | non-streaming response (`POST /v1/chat/completions`)   | supported + tested      | `tests/e2e/chat-completions.e2e.test.ts` mocks `globalThis.fetch`, asserts 200 + canonical `chat.completion` shape |
+| openai-compatible    | chat_completions   | streaming SSE (`stream:true`)                          | supported + tested      | `tests/e2e/chat-completions.e2e.test.ts` asserts `text/event-stream` framing + terminal `data: [DONE]` |
+| openai-compatible    | chat_completions   | tool calling round-trip                                | supported + tested      | `tests/e2e/tools.e2e.test.ts` — request includes `tools`, downstream returns OpenAI `tool_calls`, response surfaces them |
+| openai-compatible    | responses          | non-streaming passthrough (`POST /v1/responses`)       | supported + tested      | `tests/e2e/responses.e2e.test.ts` configures provider with `protocols: ["chat_completions","responses"]` |
+| openai-compatible    | responses          | streaming SSE                                          | supported + untested    | implementation lives in `streamResponsesDownstream`; no e2e yet — covered indirectly by unit tests in `tests/downstream.test.ts` |
+| anthropic-sdk        | chat_completions   | non-streaming, OpenAI-shape input → Anthropic translation | supported + tested   | `tests/e2e/anthropic-translation.e2e.test.ts` mocks `globalThis.fetch` (the Anthropic SDK hits it under the hood) and asserts the upstream payload is in Anthropic shape |
+| anthropic-sdk        | chat_completions   | streaming SSE                                          | supported + untested    | covered by unit tests (`streamAnthropicToOpenAI`); no e2e yet |
+| anthropic-sdk        | chat_completions   | tool calling round-trip                                | supported + untested    | covered by `tests/downstream.test.ts` ("callDownstream — tools forwarding to Anthropic SDK"); no e2e |
+| anthropic-sdk        | chat_completions   | `cache_control` injection on translated requests       | supported + tested      | `tests/e2e/anthropic-translation.e2e.test.ts` asserts ephemeral `cache_control` on the last tool/message block |
+| anthropic-sdk        | chat_completions   | `cache_read` / `cache_creation` usage surfacing        | supported + untested    | covered by unit tests; no e2e |
+| anthropic-sdk        | responses          | non-streaming + streaming                              | intentionally unsupported | the Anthropic SDK adapter does not implement `callResponses` / `streamResponses`; routing rejects responses requests for anthropic-sdk providers |
+| any                  | n/a                | `GET /health`                                          | supported + tested      | `tests/app.test.ts` |
+| any                  | n/a                | `GET /ready` (200 with providers)                      | supported + tested      | `tests/e2e/health-readiness.e2e.test.ts` |
+| any                  | n/a                | `GET /ready` (503 with no providers)                   | supported + tested      | `tests/e2e/health-readiness.e2e.test.ts` |
+| any                  | n/a                | `POST /v1/route/resolve` (no dispatch)                 | supported + tested      | `tests/e2e/route-resolve.e2e.test.ts` asserts `globalThis.fetch` is never called |
+| any                  | n/a                | cross-provider failover on retryable errors            | supported + untested    | covered by unit tests in `tests/downstream.test.ts`; no e2e |
+
+## Heavier integration coverage
+
+A real integration suite that hits a live LiteLLM or Anthropic endpoint is
+intentionally out of scope for the default CI run — it's flaky, slow, and
+requires secrets. The e2e suite under `tests/e2e/` mocks at the network
+boundary (`globalThis.fetch`), which is what both the openai-compatible
+adapter and the Anthropic SDK use. If/when a live integration suite is
+added it should run as a separate, optional CI job.
+
+## How to add a row
+
+1. Pick the (provider kind × protocol × feature) cell.
+2. Add a focused test under `tests/e2e/` that drives it through `createApp()`.
+3. Update the row's status to "supported + tested" with a link to the test.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --exclude 'tests/e2e/**'",
-    "test:e2e": "vitest run 'tests/e2e/**'",
+    "test:e2e": "vitest run --dir tests/e2e",
     "test:all": "vitest run",
     "check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run",
+    "test": "vitest run --exclude 'tests/e2e/**'",
+    "test:e2e": "vitest run 'tests/e2e/**'",
+    "test:all": "vitest run",
     "check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {

--- a/tests/e2e/anthropic-translation.e2e.test.ts
+++ b/tests/e2e/anthropic-translation.e2e.test.ts
@@ -1,0 +1,112 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
+import { __resetAnthropicClientForTests } from "../../src/downstream.js";
+import { __resetProviderRegistryForTests } from "../../src/providers/registry.js";
+
+const anthropicJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("e2e: OpenAI-shape input → Anthropic translation (anthropic-sdk)", () => {
+  const previous = {
+    mode: config.downstreamMode,
+    oauth: config.anthropicOauthToken,
+    apiKey: config.anthropicApiKey,
+    baseUrl: config.anthropicBaseUrl,
+    providers: config.providers,
+    fallback: config.downstreamMockFallbackEnabled,
+    cache: config.anthropicPromptCacheEnabled,
+  };
+
+  beforeEach(() => {
+    config.downstreamMode = "anthropic-sdk";
+    config.anthropicOauthToken = "sk-ant-oat01-test";
+    config.anthropicApiKey = undefined;
+    config.anthropicBaseUrl = "http://anthropic.test";
+    config.downstreamMockFallbackEnabled = false;
+    config.anthropicPromptCacheEnabled = true;
+    config.providers = [];
+    __resetProviderRegistryForTests();
+    __resetAnthropicClientForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    config.downstreamMode = previous.mode;
+    config.anthropicOauthToken = previous.oauth;
+    config.anthropicApiKey = previous.apiKey;
+    config.anthropicBaseUrl = previous.baseUrl;
+    config.providers = previous.providers;
+    config.downstreamMockFallbackEnabled = previous.fallback;
+    config.anthropicPromptCacheEnabled = previous.cache;
+    __resetProviderRegistryForTests();
+    __resetAnthropicClientForTests();
+  });
+
+  it("translates an OpenAI request to Anthropic shape, injects ephemeral cache_control, and returns chat.completion", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      anthropicJson({
+        id: "msg_e2e_1",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "hello from claude" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      }),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "claude-sonnet-4-6",
+        messages: [
+          { role: "system", content: "be terse" },
+          { role: "user", content: "first turn" },
+          { role: "assistant", content: "ack" },
+          { role: "user", content: "second turn" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe("chat.completion");
+    expect(res.body.choices?.[0]?.message?.content).toBe("hello from claude");
+    expect(res.body.choices?.[0]?.finish_reason).toBe("stop");
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const lastCall = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1]!;
+    const init = lastCall[1] as RequestInit;
+    const sent = JSON.parse(String(init.body));
+    // Anthropic shape: top-level system + messages array of role/content blocks.
+    expect(sent.model).toBe("claude-sonnet-4-6");
+    expect(Array.isArray(sent.messages)).toBe(true);
+    expect(sent.messages[0].role).toBe("user");
+    // System prompt is hoisted to top-level. Under the Anthropic OAuth path the
+    // first system block is the Claude Code identity prefix (no cache_control);
+    // the user's "be terse" system block lives after it and carries the marker.
+    expect(Array.isArray(sent.system)).toBe(true);
+    const cachedSystem = (sent.system as Array<{ cache_control?: unknown }>).find(
+      (b) => b.cache_control,
+    );
+    expect(cachedSystem?.cache_control).toEqual({ type: "ephemeral" });
+    // The last block of the last message also carries ephemeral cache_control
+    // when there are >=2 messages (multi-turn prefix caching).
+    const lastMsg = sent.messages[sent.messages.length - 1];
+    const lastBlock = Array.isArray(lastMsg.content)
+      ? lastMsg.content[lastMsg.content.length - 1]
+      : null;
+    expect(lastBlock?.cache_control).toEqual({ type: "ephemeral" });
+  });
+});

--- a/tests/e2e/chat-completions.e2e.test.ts
+++ b/tests/e2e/chat-completions.e2e.test.ts
@@ -1,0 +1,154 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
+import { __resetProviderRegistryForTests } from "../../src/providers/registry.js";
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+const sseResponse = (frames: string[]): Response => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const f of frames) controller.enqueue(encoder.encode(f));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+};
+
+describe("e2e: POST /v1/chat/completions (openai-compatible)", () => {
+  const previous = {
+    mode: config.downstreamMode,
+    baseUrl: config.downstreamBaseUrl,
+    apiKey: config.downstreamApiKey,
+    authMode: config.downstreamAuthMode,
+    fallback: config.downstreamMockFallbackEnabled,
+    providers: config.providers,
+  };
+
+  beforeEach(() => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamBaseUrl = "http://upstream.test/v1";
+    config.downstreamApiKey = "test-key";
+    config.downstreamAuthMode = "bearer";
+    config.downstreamMockFallbackEnabled = false;
+    config.providers = [];
+    __resetProviderRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    config.downstreamMode = previous.mode;
+    config.downstreamBaseUrl = previous.baseUrl;
+    config.downstreamApiKey = previous.apiKey;
+    config.downstreamAuthMode = previous.authMode;
+    config.downstreamMockFallbackEnabled = previous.fallback;
+    config.providers = previous.providers;
+    __resetProviderRegistryForTests();
+  });
+
+  it("returns a canonical OpenAI chat.completion shape end-to-end (non-stream)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okJson({
+        id: "chatcmpl-e2e-1",
+        object: "chat.completion",
+        created: 1700000000,
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "hello from e2e" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+      }),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "say hi" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe("chat.completion");
+    expect(res.body.choices?.[0]?.message?.role).toBe("assistant");
+    expect(res.body.choices?.[0]?.message?.content).toBe("hello from e2e");
+    expect(res.body.choices?.[0]?.finish_reason).toBe("stop");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      "http://upstream.test/v1/chat/completions",
+    );
+  });
+
+  it("streams SSE with data: framed chunks and a terminal [DONE]", async () => {
+    const frames = [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-e2e-stream",
+        object: "chat.completion.chunk",
+        created: 1700000000,
+        model: "gpt-4o-mini",
+        choices: [{ index: 0, delta: { role: "assistant", content: "hi" }, finish_reason: null }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-e2e-stream",
+        object: "chat.completion.chunk",
+        created: 1700000000,
+        model: "gpt-4o-mini",
+        choices: [{ index: 0, delta: { content: " there" }, finish_reason: null }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-e2e-stream",
+        object: "chat.completion.chunk",
+        created: 1700000000,
+        model: "gpt-4o-mini",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+      `data: [DONE]\n\n`,
+    ];
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(sseResponse(frames));
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .buffer(true)
+      .parse((response, cb) => {
+        let text = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk: string) => {
+          text += chunk;
+        });
+        response.on("end", () => cb(null, text));
+      })
+      .send({
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "say hi" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/event-stream");
+    const text = res.body as unknown as string;
+    expect(typeof text).toBe("string");
+    const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+    expect(dataLines.length).toBeGreaterThan(0);
+    expect(dataLines[dataLines.length - 1]).toBe("data: [DONE]");
+    // First payload-bearing chunk must be a chat.completion.chunk delta.
+    const firstPayload = dataLines.find((l) => l !== "data: [DONE]");
+    expect(firstPayload).toBeDefined();
+    const parsed = JSON.parse(firstPayload!.replace(/^data:\s*/, ""));
+    expect(parsed.object).toBe("chat.completion.chunk");
+  });
+});

--- a/tests/e2e/health-readiness.e2e.test.ts
+++ b/tests/e2e/health-readiness.e2e.test.ts
@@ -1,0 +1,63 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
+import { __resetProviderRegistryForTests } from "../../src/providers/registry.js";
+
+describe("e2e: GET /health and GET /ready", () => {
+  const previous = {
+    mode: config.downstreamMode,
+    baseUrl: config.downstreamBaseUrl,
+    fallback: config.downstreamMockFallbackEnabled,
+    providers: config.providers,
+  };
+
+  beforeEach(() => {
+    __resetProviderRegistryForTests();
+  });
+
+  afterEach(() => {
+    config.downstreamMode = previous.mode;
+    config.downstreamBaseUrl = previous.baseUrl;
+    config.downstreamMockFallbackEnabled = previous.fallback;
+    config.providers = previous.providers;
+    __resetProviderRegistryForTests();
+  });
+
+  it("/health is always 200", async () => {
+    const app = createApp();
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("/ready returns 200 with at least one chat-capable provider", async () => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamBaseUrl = "http://upstream.test/v1";
+    config.downstreamMockFallbackEnabled = true;
+    config.providers = [];
+    __resetProviderRegistryForTests();
+
+    const app = createApp();
+    const res = await request(app).get("/ready");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.providerCount).toBeGreaterThan(0);
+    expect(Array.isArray(res.body.diagnostics?.providers)).toBe(true);
+  });
+
+  it("/ready returns 503 when no providers can be synthesized", async () => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamBaseUrl = null;
+    config.downstreamMockFallbackEnabled = false;
+    config.providers = [];
+    __resetProviderRegistryForTests();
+
+    const app = createApp();
+    const res = await request(app).get("/ready");
+    expect(res.status).toBe(503);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.reasons).toContain("no providers are registered");
+  });
+});

--- a/tests/e2e/responses.e2e.test.ts
+++ b/tests/e2e/responses.e2e.test.ts
@@ -1,0 +1,83 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
+import { __resetProviderRegistryForTests } from "../../src/providers/registry.js";
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("e2e: POST /v1/responses (openai-compatible passthrough)", () => {
+  const previous = {
+    providers: config.providers,
+    mode: config.downstreamMode,
+    fallback: config.downstreamMockFallbackEnabled,
+  };
+
+  beforeEach(() => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamMockFallbackEnabled = false;
+    config.providers = [
+      {
+        id: "default",
+        kind: "openai-compatible",
+        baseUrl: "http://upstream.test/v1",
+        protocols: ["chat_completions", "responses"],
+        auth: { mode: "bearer", apiKey: "test-key" },
+        models: [{ id: "gpt-5" }],
+      },
+    ];
+    __resetProviderRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    config.providers = previous.providers;
+    config.downstreamMode = previous.mode;
+    config.downstreamMockFallbackEnabled = previous.fallback;
+    __resetProviderRegistryForTests();
+  });
+
+  it("forwards a non-streaming Responses request to /responses and returns the upstream body verbatim", async () => {
+    const upstreamBody = {
+      id: "resp_e2e_1",
+      object: "response",
+      created_at: 1700000000,
+      model: "gpt-5",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello from responses" }],
+        },
+      ],
+      usage: { input_tokens: 4, output_tokens: 6, total_tokens: 10 },
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson(upstreamBody));
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/responses")
+      .send({
+        model: "gpt-5",
+        input: [{ role: "user", content: [{ type: "input_text", text: "say hi" }] }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe("response");
+    expect(res.body.id).toBe("resp_e2e_1");
+    expect(res.body.output?.[0]?.content?.[0]?.text).toBe("hello from responses");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("http://upstream.test/v1/responses");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(String(init.body));
+    expect(body.model).toBe("gpt-5");
+    expect(Array.isArray(body.input)).toBe(true);
+  });
+});

--- a/tests/e2e/route-resolve.e2e.test.ts
+++ b/tests/e2e/route-resolve.e2e.test.ts
@@ -1,0 +1,65 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
+import { __resetProviderRegistryForTests } from "../../src/providers/registry.js";
+
+describe("e2e: POST /v1/route/resolve", () => {
+  const previous = {
+    mode: config.downstreamMode,
+    fallback: config.downstreamMockFallbackEnabled,
+    rules: config.routingRules,
+  };
+
+  beforeEach(() => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamMockFallbackEnabled = true;
+    config.routingRules = [];
+    __resetProviderRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    config.downstreamMode = previous.mode;
+    config.downstreamMockFallbackEnabled = previous.fallback;
+    config.routingRules = previous.rules;
+    __resetProviderRegistryForTests();
+  });
+
+  it("returns the route decision without invoking globalThis.fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/route/resolve")
+      .send({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "say hi" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.route).toBeDefined();
+    expect(res.body.route.requestedModel).toBe("gpt-4o");
+    expect(typeof res.body.route.resolvedModel).toBe("string");
+    expect(typeof res.body.route.providerId).toBe("string");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns a route decision for responses-protocol payloads", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/route/resolve")
+      .send({
+        protocol: "responses",
+        model: "gpt-4o",
+        input: [{ role: "user", content: [{ type: "input_text", text: "say hi" }] }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.route.protocol).toBe("responses");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/e2e/tools.e2e.test.ts
+++ b/tests/e2e/tools.e2e.test.ts
@@ -1,0 +1,104 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
+import { __resetProviderRegistryForTests } from "../../src/providers/registry.js";
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("e2e: chat_completions tool calling round-trip (openai-compatible)", () => {
+  const previous = {
+    mode: config.downstreamMode,
+    baseUrl: config.downstreamBaseUrl,
+    apiKey: config.downstreamApiKey,
+    authMode: config.downstreamAuthMode,
+    fallback: config.downstreamMockFallbackEnabled,
+    providers: config.providers,
+  };
+
+  beforeEach(() => {
+    config.downstreamMode = "openai-compatible";
+    config.downstreamBaseUrl = "http://upstream.test/v1";
+    config.downstreamApiKey = "test-key";
+    config.downstreamAuthMode = "bearer";
+    config.downstreamMockFallbackEnabled = false;
+    config.providers = [];
+    __resetProviderRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    config.downstreamMode = previous.mode;
+    config.downstreamBaseUrl = previous.baseUrl;
+    config.downstreamApiKey = previous.apiKey;
+    config.downstreamAuthMode = previous.authMode;
+    config.downstreamMockFallbackEnabled = previous.fallback;
+    config.providers = previous.providers;
+    __resetProviderRegistryForTests();
+  });
+
+  it("forwards tools to the upstream and surfaces tool_calls on the response", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      okJson({
+        id: "chatcmpl-tools-1",
+        object: "chat.completion",
+        created: 1700000000,
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "call_abc",
+                  type: "function",
+                  function: { name: "gpu_status", arguments: '{"verbose":true}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      }),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .send({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "check the gpu" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "gpu_status",
+              description: "Report GPU state",
+              parameters: { type: "object", properties: { verbose: { type: "boolean" } } },
+            },
+          },
+        ],
+        tool_choice: "auto",
+      });
+
+    expect(res.status).toBe(200);
+    const msg = res.body.choices?.[0]?.message;
+    expect(msg.tool_calls).toHaveLength(1);
+    expect(msg.tool_calls[0].function.name).toBe("gpu_status");
+    expect(res.body.choices[0].finish_reason).toBe("tool_calls");
+
+    // Upstream payload must carry the tools array verbatim (openai-compatible).
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const sentBody = JSON.parse(String(init.body));
+    expect(Array.isArray(sentBody.tools)).toBe(true);
+    expect(sentBody.tools[0].function.name).toBe("gpu_status");
+    expect(sentBody.tool_choice).toBe("auto");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `docs/compatibility.md` — a (provider kind × protocol × feature) matrix that explicitly tags each cell as supported+tested / supported+untested / intentionally unsupported / known-gap, linked from README under a new "Compatibility" heading.
- Adds 6 e2e files under `tests/e2e/` (10 tests) driving `createApp()` with `supertest` and mocking at the network boundary (`globalThis.fetch`):
  - `chat-completions.e2e.test.ts` — non-stream + streaming SSE (asserts `data:` framing + terminal `[DONE]`)
  - `responses.e2e.test.ts` — `/v1/responses` passthrough (provider configured with `protocols: ["chat_completions","responses"]`)
  - `tools.e2e.test.ts` — chat_completions tool calling round-trip (request `tools` → upstream → `tool_calls` on response)
  - `anthropic-translation.e2e.test.ts` — OpenAI→Anthropic translation + ephemeral `cache_control` injection on system + last-message blocks
  - `route-resolve.e2e.test.ts` — `/v1/route/resolve` returns route shape, never invokes `globalThis.fetch`
  - `health-readiness.e2e.test.ts` — `/health` 200, `/ready` 200 with providers, 503 with no providers
- Splits npm scripts: `test` runs unit suite (excludes `tests/e2e/**`), new `test:e2e` runs only e2e, new `test:all` runs both. CI runs them as two separate required steps.

## What's intentionally not yet covered

Per the matrix in `docs/compatibility.md`:
- responses streaming SSE — supported in code (`streamResponsesDownstream`), unit-tested only
- anthropic-sdk streaming SSE + tool calling round-trip — unit-tested only
- cross-provider failover end-to-end — unit-tested only
- A live integration suite hitting real LiteLLM/Anthropic stays out of scope (flaky, needs secrets); mocking at `globalThis.fetch` covers both the openai-compatible and anthropic-sdk adapters since the SDK uses fetch under the hood.

`anthropic-sdk` × `responses` is marked intentionally unsupported (the adapter does not implement `callResponses`/`streamResponses`).

## Test plan

- [x] `npm run check` — clean
- [x] `npm test` — 118 unit tests pass
- [x] `npm run test:e2e` — 10 e2e tests pass
- [ ] CI runs unit + e2e steps separately, both green

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)