### PR TITLE
fix(openai-compatible): propagate X-AgentWeave-* headers on all paths

### DIFF
--- a/docs/deploy-debian.md
+++ b/docs/deploy-debian.md
@@ -225,9 +225,20 @@ completes.
 
 ## Plumbing with OpenClaw + AgentWeave
 
+The canonical chain on this NAS deploy is:
+
 ```
-OpenClaw agent ─► AgentWeave proxy ─► Mux ─► LiteLLM/Anthropic/OpenAI
+OpenClaw agent ─► Mux ─► AgentWeave proxy ─► LiteLLM/Anthropic/OpenAI
 ```
+
+Mux is the policy/routing layer in front of the AgentWeave proxy.
+OpenClaw sends to Mux; Mux's per-provider `baseUrl` points at the
+AgentWeave proxy NodePort; the proxy in turn forwards to the real
+upstream and emits OTel spans to Tempo.
+
+(The inverted chain — OpenClaw → AgentWeave proxy → Mux → upstream — is
+also supported by the Mux code, but the NAS today uses the topology
+above. Pick one and document which.)
 
 ### OpenClaw → Mux
 
@@ -251,19 +262,27 @@ landing on Mux's `/v1/responses` and `/v1/chat/completions`.
 > back to `api.openai.com` / `chatgpt.com` and bypass Mux entirely. Make
 > sure the OpenClaw build is at or after that commit.
 
-### AgentWeave → Mux
+### Mux → AgentWeave proxy
 
-If routing through AgentWeave's Python proxy first, point its upstream at
-Mux and use:
+For each provider entry in Mux's `PROVIDERS` (or the legacy
+`DOWNSTREAM_BASE_URL`), set `baseUrl` to the AgentWeave proxy NodePort:
 
-```ini
-DOWNSTREAM_AUTH_MODE=passthrough
+```jsonc
+{
+  "id": "agentweave-anthropic",
+  "kind": "anthropic-sdk",
+  "baseUrl": "http://192.168.1.70:30400",
+  "auth": { "mode": "anthropic-oauth", "oauthToken": "sk-ant-oat01-..." },
+  "models": [ /* … */ ]
+}
 ```
 
-so Mux forwards the inbound `Authorization` header to the eventual
-downstream. AgentWeave PR #183 reroutes `/v1/responses` calls carrying
-ChatGPT-mode JWTs to `chatgpt.com/backend-api/codex/responses` — that
-rewrite happens inside AgentWeave's proxy and is independent of Mux.
+Use `auth.mode = "passthrough"` (openai-compatible) when OpenClaw is
+already supplying an end-to-end JWT (Codex ChatGPT-mode) and you don't
+want Mux to rewrite the header. AgentWeave PR #183 reroutes
+`/v1/responses` calls carrying ChatGPT-mode JWTs to
+`chatgpt.com/backend-api/codex/responses` — that rewrite happens inside
+AgentWeave's proxy and is independent of Mux.
 
 ### Caller agent attribution
 

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -4,6 +4,7 @@ import { setSpanAttrs, withLlmSpan } from "../tracing.js";
 import { computeCostUsd, resolveCallerAgentId } from "./cost.js";
 import type { ChatCompletionsRequest, ResponsesRequest, RouteDecision } from "../types.js";
 import {
+  buildAgentweaveHeaders,
   buildMockResponse,
   buildMockResponsesResponse,
   DownstreamRequestError,
@@ -99,6 +100,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
       const headers: Record<string, string> = {
         "content-type": "application/json",
         ...(cfg.extraHeaders ?? {}),
+        ...buildAgentweaveHeaders(context),
       };
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
@@ -183,6 +185,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
       const headers: Record<string, string> = {
         "content-type": "application/json",
         ...(cfg.extraHeaders ?? {}),
+        ...buildAgentweaveHeaders(context),
       };
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
@@ -237,6 +240,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
         "content-type": "application/json",
         accept: "text/event-stream",
         ...(cfg.extraHeaders ?? {}),
+        ...buildAgentweaveHeaders(context),
       };
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;
@@ -308,6 +312,7 @@ export const createOpenAICompatibleProvider = (cfg: ProviderConfig): Provider =>
         "content-type": "application/json",
         accept: "text/event-stream",
         ...(cfg.extraHeaders ?? {}),
+        ...buildAgentweaveHeaders(context),
       };
       const auth = resolveAuthHeaderForProvider(cfg, context);
       if (auth) headers[auth.header] = auth.value;

--- a/tests/downstream.test.ts
+++ b/tests/downstream.test.ts
@@ -4,6 +4,7 @@ import { config } from "../src/config.js";
 import {
   __resetAnthropicClientForTests,
   callDownstream,
+  callResponsesDownstream,
   DownstreamNotConfiguredError,
   DownstreamRequestError,
   anthropicStopReasonToOpenAI,
@@ -11,12 +12,13 @@ import {
   isRetryableDownstreamError,
   streamAnthropicToOpenAI,
   streamDownstream,
+  streamResponsesDownstream,
   toAnthropicInput,
   toOpenAIResponse,
   translateToolChoiceToAnthropic,
   translateToolsToAnthropic,
 } from "../src/downstream.js";
-import type { ChatCompletionsRequest, OpenAIToolDef, RouteDecision } from "../src/types.js";
+import type { ChatCompletionsRequest, OpenAIToolDef, ResponsesRequest, RouteDecision } from "../src/types.js";
 
 const requestPayload: ChatCompletionsRequest = {
   model: "gpt-4o",
@@ -2751,6 +2753,166 @@ describe("streamDownstream — headers-sent guard with retryable mid-stream erro
       expect(res.writes.join("")).toContain("partial-from-a");
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/^http:\/\/a\//);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("openai-compatible — AgentWeave header propagation", () => {
+  const setupProvider = (protocols: Array<"chat_completions" | "responses"> = ["chat_completions", "responses"]) => {
+    const previousProviders = config.providers;
+    config.providers = [
+      {
+        id: "agentweave-codex",
+        kind: "openai-compatible",
+        baseUrl: "http://proxy.test/v1",
+        protocols,
+        auth: { mode: "passthrough" },
+        models: [{ id: "gpt-4o-mini", costInputUsdPerMTok: 0.1, costOutputUsdPerMTok: 0.4 }],
+      },
+    ];
+    __resetAnthropicClientForTests();
+    return () => {
+      config.providers = previousProviders;
+      __resetAnthropicClientForTests();
+    };
+  };
+
+  const routeFor = (protocol: "chat_completions" | "responses"): RouteDecision => ({
+    requestedModel: "gpt-4o-mini",
+    resolvedModel: "gpt-4o-mini",
+    routeReason: "test",
+    provider: "openai-compatible",
+    backendTarget: "http://proxy.test/v1",
+    providerId: "agentweave-codex",
+    fallbackProviderIds: [],
+    protocol,
+  });
+
+  const callerHeaders = {
+    "x-agentweave-agent-id": "nix-v1",
+    "x-agentweave-session-id": "nix-main",
+    "x-agentweave-project": "nix",
+    "x-agentweave-agent-type": "main",
+  };
+
+  const okChatResponse = () =>
+    new Response(
+      JSON.stringify({
+        id: "x", object: "chat.completion", created: 1, model: "gpt-4o-mini",
+        choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const okResponsesResponse = () =>
+    new Response(
+      JSON.stringify({ id: "r1", object: "response", model: "gpt-4o-mini", output: [] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const trivialSseResponse = () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+    return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+  };
+
+  // Minimal stub matching the surface used by the openai-compatible adapter
+  // when streaming. We don't validate the stream itself — only that fetch was
+  // invoked with the expected headers.
+  const makeStreamRes = () => {
+    const res = {
+      statusCode: 0,
+      headersSent: false,
+      headers: {} as Record<string, string>,
+      writes: [] as string[],
+      ended: false,
+      _listeners: {} as Record<string, Array<() => void>>,
+      status(code: number) { res.statusCode = code; return res; },
+      setHeader(k: string, v: string) { res.headers[k] = v; },
+      getHeader(k: string) { return res.headers[k]; },
+      write(chunk: string) { res.headersSent = true; res.writes.push(chunk); return true; },
+      end() { res.ended = true; },
+      once(_event: string, _cb: () => void) {},
+      off(_event: string, _cb: () => void) {},
+      emit(_event: string) {},
+    };
+    return res;
+  };
+
+  const assertAgentweaveHeaders = (headers: Record<string, string>) => {
+    expect(headers["x-agentweave-agent-id"]).toBe("nix-v1");
+    expect(headers["x-agentweave-session-id"]).toBe("nix-main");
+    expect(headers["x-agentweave-project"]).toBe("nix");
+    expect(headers["x-agentweave-agent-type"]).toBe("main");
+  };
+
+  it("call (chat) forwards x-agentweave-* headers to the downstream", async () => {
+    const restore = setupProvider();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okChatResponse());
+      await callDownstream(requestPayload, routeFor("chat_completions"), {
+        agentweaveHeaders: callerHeaders,
+      });
+      const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+      assertAgentweaveHeaders(headers);
+    } finally {
+      restore();
+    }
+  });
+
+  it("stream (chat) forwards x-agentweave-* headers to the downstream", async () => {
+    const restore = setupProvider();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(trivialSseResponse());
+      const res = makeStreamRes();
+      await streamDownstream(
+        { ...requestPayload, stream: true },
+        routeFor("chat_completions"),
+        res as unknown as import("express").Response,
+        { agentweaveHeaders: callerHeaders },
+      );
+      const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+      assertAgentweaveHeaders(headers);
+    } finally {
+      restore();
+    }
+  });
+
+  it("callResponses forwards x-agentweave-* headers to the downstream", async () => {
+    const restore = setupProvider();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(okResponsesResponse());
+      const responsesReq: ResponsesRequest = { model: "gpt-4o-mini", input: "hi" };
+      await callResponsesDownstream(responsesReq, routeFor("responses"), {
+        agentweaveHeaders: callerHeaders,
+      });
+      const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+      assertAgentweaveHeaders(headers);
+    } finally {
+      restore();
+    }
+  });
+
+  it("streamResponses forwards x-agentweave-* headers to the downstream", async () => {
+    const restore = setupProvider();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(trivialSseResponse());
+      const responsesReq: ResponsesRequest = { model: "gpt-4o-mini", input: "hi", stream: true };
+      const res = makeStreamRes();
+      await streamResponsesDownstream(
+        responsesReq,
+        routeFor("responses"),
+        res as unknown as import("express").Response,
+        { agentweaveHeaders: callerHeaders },
+      );
+      const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+      assertAgentweaveHeaders(headers);
     } finally {
       restore();
     }


### PR DESCRIPTION
## Summary

- The `openai-compatible` provider adapter was building request headers from `extraHeaders` + auth only, dropping the inbound `X-AgentWeave-*` headers that `app.ts` extracts and forwards via `DownstreamRequestContext.agentweaveHeaders`. So when Mux's downstream is an AgentWeave-aware target (e.g. the `agentweave-proxy` NodePort 30400), the proxy received no caller attribution and bucketed traffic as \"unknown\".
- Adds `...buildAgentweaveHeaders(context)` to all four `openai-compatible` code paths: `call`, `stream`, `callResponses`, `streamResponses`. Matches the `anthropic-sdk` adapter, which has propagated these headers since #50.
- Adds four regression tests inspecting fetched request headers — there was no coverage for header propagation before this PR.
- Corrects `docs/deploy-debian.md`: the previous diagram had Mux downstream of the AgentWeave proxy, but the live NAS `PROVIDERS` config sets per-provider `baseUrl` to the AgentWeave proxy NodePort — Mux is *upstream* of the proxy. Doc now reflects the canonical chain `OpenClaw → Mux → AgentWeave proxy → upstream`.

Refs #67 (partial fix — this PR only addresses the latent header-propagation bug; rerouting OpenClaw's primary anthropic/codex traffic through Mux is a separate follow-up).

## Test plan

- [x] `npm test` — 122 tests passing (was 118, 4 new tests added)
- [x] `npm run build` — `tsc` clean
- [ ] After merge: redeploy on NAS and confirm an AgentWeave-routed openai-compatible request carries `x-agentweave-*` headers via `journalctl --user -u mux.service` (no log line dump needed — but you can inspect via `tcpdump` or by enabling `agentweave-proxy` request logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)